### PR TITLE
[team]Fix invalid team member's githubId.

### DIFF
--- a/src/pages/team/languages.json
+++ b/src/pages/team/languages.json
@@ -277,8 +277,8 @@
         "apacheId": "lidongdai",
         "avatarUrl": "https://avatars.githubusercontent.com/u/15833811?v=4",
         "email": "lidongdai@apache.org",
-        "gitUrl": "https://github.com/dailidong",
-        "githubId": "dailidong",
+        "gitUrl": "https://github.com/davidzollo",
+        "githubId": "davidzollo",
         "name": "Lidong Dai"
       }
     ],


### PR DESCRIPTION
In team page, the github id of `Lidong Dai` is invalid.