### PR TITLE
[doc]Added single quote to spark shell cmd around --master flag

### DIFF
--- a/versioned_docs/version-2.3.2/start-v2/locally/quick-start-spark.md
+++ b/versioned_docs/version-2.3.2/start-v2/locally/quick-start-spark.md
@@ -71,7 +71,7 @@ spark 2.4.x
 ```bash
 cd "apache-seatunnel-incubating-${version}"
 ./bin/start-seatunnel-spark-2-connector-v2.sh \
---master local[4] \
+--master 'local[4]' \
 --deploy-mode client \
 --config ./config/seatunnel.streaming.conf.template
 ```
@@ -81,7 +81,7 @@ spark3.x.x
 ```shell
 cd "apache-seatunnel-incubating-${version}"
 ./bin/start-seatunnel-spark-3-connector-v2.sh \
---master local[4] \
+--master 'local[4]' \
 --deploy-mode client \
 --config ./config/seatunnel.streaming.conf.template
 ```


### PR DESCRIPTION
- In order to avoid the error "no matches found: local[4]", Added single quote around the value of --master flag for Spark shell cmd