### PR TITLE
Fixbug: incorrect download URL in start-k8s

### DIFF
--- a/versioned_docs/version-2.3.2/start-v2/kubernetes/kubernetes.mdx
+++ b/versioned_docs/version-2.3.2/start-v2/kubernetes/kubernetes.mdx
@@ -47,11 +47,11 @@ ENV SEATUNNEL_HOME = "/opt/seatunnel"
 
 RUN mkdir -p $SEATUNNEL_HOME
 
-RUN wget https://archive.apache.org/dist/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-incubating-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-incubating-${SEATUNNEL_VERSION}-bin.tar.gz
+RUN wget https://archive.apache.org/dist/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
+RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
 
-RUN cp -r apache-seatunnel-incubating-${SEATUNNEL_VERSION}/* $SEATUNNEL_HOME/
-RUN rm -rf apache-seatunnel-incubating-${SEATUNNEL_VERSION}*
+RUN cp -r apache-seatunnel-${SEATUNNEL_VERSION}/* $SEATUNNEL_HOME/
+RUN rm -rf apache-seatunnel-${SEATUNNEL_VERSION}*
 ```
 
 Then run the following commands to build the image:

--- a/versioned_docs/version-2.3.2/start-v2/kubernetes/kubernetes.mdx
+++ b/versioned_docs/version-2.3.2/start-v2/kubernetes/kubernetes.mdx
@@ -43,7 +43,7 @@ To run the image with SeaTunnel, first create a `Dockerfile`:
 FROM flink:1.13
 
 ENV SEATUNNEL_VERSION="2.3.2"
-ENV SEATUNNEL_HOME = "/opt/seatunnel"
+ENV SEATUNNEL_HOME="/opt/seatunnel"
 
 RUN mkdir -p $SEATUNNEL_HOME
 


### PR DESCRIPTION
The download URL has changed since v2.3.2.

<img width="1439" alt="image" src="https://github.com/apache/seatunnel-website/assets/23008405/a5c8c800-f497-445c-b19d-12d3f3188bef">
