### PR TITLE
Revert "Update rest-api.md (#274)"

### DIFF
--- a/versioned_docs/version-2.3.3/seatunnel-engine/rest-api.md
+++ b/versioned_docs/version-2.3.3/seatunnel-engine/rest-api.md
@@ -234,29 +234,6 @@ network:
 }
 ```
 
-### Stop Job.
-
-<details>
-
- <summary><code>POST</code> <code><b>/hazelcast/rest/maps/stop-job</b></code> <code>(Returns jobId if job stoped successfully.)</code></summary>
-
-#### Body
-
-```json
-{
-    "jobId": 733584788375666689,
-    "isStopWithSavePoint": false # if job is stopped with save point
-}
-```
-
-#### Responses
-
-```json
-{
-"jobId": 733584788375666689
-}
-```
-
 </details>
 
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR reverts commit 85fd3d63404f3532c368da1f077bcbc655478ab0.
Because rest-api supported stop job not released on 2.3.3.
![image](https://github.com/apache/seatunnel-website/assets/32387433/d4e325f1-ea19-4893-bf5e-dc91b9b8403a)
https://github.com/apache/seatunnel/commit/8d2fafcf269de1be6964e39dec4b88c6e43d4afb