### PR TITLE
Remove link to ASF-wide security page from the menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -172,10 +172,6 @@ const config = {
               to: "https://www.apache.org/events/current-event",
             },
             {
-              label: "Security",
-              to: "https://www.apache.org/security/",
-            },
-            {
               label: "Sponsorship",
               to: "https://www.apache.org/foundation/sponsorship.html",
             },


### PR DESCRIPTION
To make the link to the project-specific security page (which links to the ASF-wide security page, but also adds project-specific information) more prominent.