### PR TITLE
[Fix][Seatunnel-website] Sink's plugin_input is incorrect configurations

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.11/concept/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.11/concept/config.md
@@ -113,7 +113,7 @@ sink {
     fields = ["name", "age", "card"]
     username = "default"
     password = ""
-    plugin_input = "fake1"
+    plugin_input = "fake"
   }
 }
 ```


### PR DESCRIPTION
@Hisoka-X  Hello, pls help to review it.

Sink's `plugin_input` is incorrect configurations,it should be same with Source's `plugin_output`.

Although it does not affect task execution, this is an incorrect method and is not recommended. Placing it in the official documentation can cause confusion. 

https://github.com/apache/seatunnel/blob/9777ecb4e4ed271310d4de65b572acd7f30ae31d/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/ConfigParserUtil.java#L112