### PR TITLE
Fixed the JDK name and ensured consistent network names throughout the document.

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/docker/docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 Dockerfile文件内容为：
 ```dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image
@@ -223,14 +223,13 @@ docker run -d --name seatunnel_worker_1 \
 ### 使用docker-compose
 `docker-compose.yaml` 配置文件为：
 ```yaml
-version: '3.8'
-
 services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
@@ -238,14 +237,14 @@ services:
     ports:
       - "5801:5801"
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.2
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -253,14 +252,14 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.3
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -268,34 +267,30 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.4
+      - seatunnel_network
 
 networks:
   seatunnel_network:
+    name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
-运行 `docker-compose up`命令来启动集群，该配置会启动一个master节点，2个worker节点
+运行 `docker-compose up -d` 命令来启动集群，该配置会启动一个 master 节点和 2 个 worker 节点。
 
 
-启动完成后，可以运行`docker logs -f seatunnel_master`, `docker logs -f seatunnel_worker_1`来查看节点的日志  
-当你访问`http://localhost:5801/hazelcast/rest/maps/system-monitoring-information` 时，可以看到集群的状态为1个master节点，2个worker节点.
+启动完成后，可以运行 `docker logs -f seatunnel_master`、`docker logs -f seatunnel_worker_1` 查看节点日志。
+当访问 `http://localhost:5801/hazelcast/rest/maps/system-monitoring-information` 时，可以看到集群状态已经符合预期。
 
 #### 集群扩容
 当你需要对集群扩容, 例如需要添加一个worker节点时
 ```yaml
-version: '3.8'
-
 services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
@@ -303,14 +298,14 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.2
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -318,14 +313,14 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.3
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -333,16 +328,16 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.4
+      - seatunnel_network
   ####
   ## 添加新节点配置
   ####      
   worker3:
     image: apache/seatunnel
     container_name: seatunnel_worker_3
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4,172.16.0.5 # 添加ip到这里
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801,seatunnel_worker_3:5801 # 在这里补充新节点
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -350,15 +345,12 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.5        # 设置新节点ip
+      - seatunnel_network
 
 networks:
   seatunnel_network:
+    name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -367,23 +359,23 @@ networks:
 ### 提交作业到集群
 
 #### 使用docker container作为客户端
-- 提交任务
+这里需要显式使用 `-m cluster`，这样任务才会提交到上面启动的 SeaTunnel 集群。
+
+- 提交集群任务
 ```shell
-# 将ST_DOCKER_MEMBER_LIST设置为master容器的ip
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
-    ./bin/seatunnel.sh  -c config/v2.batch.config.template
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m cluster
 ```
 
 - 查看作业列表
 ```shell
-# 将ST_DOCKER_MEMBER_LIST设置为master容器的ip
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/docker/docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/docker/docker.md
@@ -359,9 +359,7 @@ networks:
 ### 提交作业到集群
 
 #### 使用docker container作为客户端
-这里需要显式使用 `-m cluster`，这样任务才会提交到上面启动的 SeaTunnel 集群。
-
-- 提交集群任务
+- 提交任务
 ```shell
 docker run --name seatunnel_client \
     --network seatunnel-network \

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -230,8 +230,9 @@ services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
@@ -240,13 +241,13 @@ services:
       - "5801:5801"  
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.2
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -255,13 +256,13 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.3
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -270,15 +271,11 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.4
 
 networks:
   seatunnel_network:
     name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -300,8 +297,9 @@ services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801  
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
@@ -310,13 +308,13 @@ services:
       - "5801:5801"  
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.2
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -325,13 +323,13 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.3
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=- ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -340,15 +338,16 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.4
+
   ####
   ## add new worker node
   ####      
   worker3:
     image: apache/seatunnel
     container_name: seatunnel_worker_3
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4,172.16.0.5 # add ip to here
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801,seatunnel_worker_3:5801 # add ip to here
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -357,15 +356,11 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.5        # use a not used ip
 
 networks:
   seatunnel_network:
     name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -375,15 +370,25 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ### Job Operation on cluster
 
 #### use docker as a client
-- submit job :
+- submit job (local):
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
-    ./bin/seatunnel.sh  -c config/v2.batch.config.template
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m local
+```
+- submit job (cluster):
+```shell
+# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
+docker run --name seatunnel_client \
+    --network seatunnel-network \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
+    --rm \
+    apache/seatunnel \
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m cluster
 ```
 
 - list job
@@ -391,7 +396,7 @@ docker run --name seatunnel_client \
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -225,8 +225,6 @@ docker run -d --name seatunnel_worker_1 \
 
 The `docker-compose.yaml` file is :
 ```yaml
-version: '3.8'
-
 services:
   master:
     image: apache/seatunnel
@@ -275,6 +273,7 @@ services:
 
 networks:
   seatunnel_network:
+    name: seatunnel_network
     driver: bridge
     ipam:
       config:

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -240,7 +240,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -255,7 +255,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker2:
     image: apache/seatunnel
@@ -270,7 +270,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
 networks:
   seatunnel_network:
@@ -307,7 +307,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -322,7 +322,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker2:
     image: apache/seatunnel
@@ -337,7 +337,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   ####
   ## add new worker node
@@ -355,7 +355,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
 networks:
   seatunnel_network:

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -372,7 +372,6 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 #### use docker as a client
 - submit job (local):
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
@@ -382,7 +381,6 @@ docker run --name seatunnel_client \
 ```
 - submit job (cluster):
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
@@ -393,7 +391,6 @@ docker run --name seatunnel_client \
 
 - list job
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -361,6 +361,7 @@ services:
 
 networks:
   seatunnel_network:
+    name: seatunnel_network
     driver: bridge
     ipam:
       config:
@@ -378,8 +379,8 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    --network seatunnel_network \
+    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -c config/v2.batch.config.template
@@ -389,8 +390,8 @@ docker run --name seatunnel_client \
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    --network seatunnel_network \
+    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 The Dockerfile is like this:
 ```dockerfile
-FROM openjdk:8
+FROM openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -274,7 +274,7 @@ services:
 
 networks:
   seatunnel_network:
-    name: seatunnel_network
+    name: seatunnel-network
     driver: bridge
     ipam:
       config:
@@ -361,7 +361,7 @@ services:
 
 networks:
   seatunnel_network:
-    name: seatunnel_network
+    name: seatunnel-network
     driver: bridge
     ipam:
       config:
@@ -379,7 +379,7 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel_network \
+    --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \
@@ -390,7 +390,7 @@ docker run --name seatunnel_client \
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel_network \
+    --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -225,6 +225,7 @@ docker run -d --name seatunnel_worker_1 \
 
 The `docker-compose.yaml` file is :
 ```yaml
+
 services:
   master:
     image: apache/seatunnel
@@ -294,7 +295,6 @@ After that, you can use client or restapi to submit job to this cluster.
 If you want to increase cluster node, like add a new work node.
 
 ```yaml
-version: '3.8'
 
 services:
   master:

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 The Dockerfile is like this:
 ```dockerfile
-FROM openjdk:8u342
+FROM seatunnelhub/openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -370,15 +370,8 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ### Job Operation on cluster
 
 #### use docker as a client
-- submit job (local):
-```shell
-docker run --name seatunnel_client \
-    --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
-    --rm \
-    apache/seatunnel \
-    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m local
-```
+Use `-m cluster` here so the job is submitted to the SeaTunnel cluster started above.
+
 - submit job (cluster):
 ```shell
 docker run --name seatunnel_client \
@@ -406,4 +399,3 @@ more command please refer [user-command](../../seatunnel-engine/user-command.md)
 #### use rest api
 
 please refer [Submit A Job](../../seatunnel-engine/rest-api-v2.md#submit-a-job)
-

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -370,9 +370,7 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ### Job Operation on cluster
 
 #### use docker as a client
-Use `-m cluster` here so the job is submitted to the SeaTunnel cluster started above.
-
-- submit job (cluster):
+- submit job:
 ```shell
 docker run --name seatunnel_client \
     --network seatunnel-network \

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -240,7 +240,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -255,7 +255,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
@@ -270,7 +270,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
 networks:
   seatunnel_network:
@@ -307,7 +307,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -322,14 +322,14 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
     restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=- ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -337,7 +337,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   ####
   ## add new worker node
@@ -355,7 +355,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
 networks:
   seatunnel_network:


### PR DESCRIPTION
1. Fix JDK name issue: OpenJDK8 is not found on Docker Hub.
<img width="1563" height="367" alt="image" src="https://github.com/user-attachments/assets/c21c0f0b-eb27-4c5c-81c8-336fc6ea3001" />

2. [Version top-level element (obsolete)](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)

3. Fix the network name so that test cases can execute correctly after cluster deployment.

4. Fix the IP addresses used in the test cases so that the specified IP addresses are consistent with the IP addresses in the compose file.