### PR TITLE
Fix docker compose YAML network syntax, worker2 env typo, and update base image

### DIFF
--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -230,8 +230,9 @@ services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
@@ -240,13 +241,13 @@ services:
       - "5801:5801"  
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.2
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -255,13 +256,13 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.3
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -270,15 +271,11 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.4
 
 networks:
   seatunnel_network:
     name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -300,8 +297,9 @@ services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801  
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
@@ -310,13 +308,13 @@ services:
       - "5801:5801"  
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.2
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -325,13 +323,13 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.3
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=- ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -340,15 +338,16 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.4
+
   ####
   ## add new worker node
   ####      
   worker3:
     image: apache/seatunnel
     container_name: seatunnel_worker_3
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4,172.16.0.5 # add ip to here
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801,seatunnel_worker_3:5801 # add ip to here
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -357,15 +356,11 @@ services:
       - master
     networks:
       seatunnel_network:
-        ipv4_address: 172.16.0.5        # use a not used ip
 
 networks:
   seatunnel_network:
     name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -375,15 +370,25 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ### Job Operation on cluster
 
 #### use docker as a client
-- submit job :
+- submit job (local):
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
-    ./bin/seatunnel.sh  -c config/v2.batch.config.template
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m local
+```
+- submit job (cluster):
+```shell
+# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
+docker run --name seatunnel_client \
+    --network seatunnel-network \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
+    --rm \
+    apache/seatunnel \
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m cluster
 ```
 
 - list job
@@ -391,7 +396,7 @@ docker run --name seatunnel_client \
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -225,8 +225,6 @@ docker run -d --name seatunnel_worker_1 \
 
 The `docker-compose.yaml` file is :
 ```yaml
-version: '3.8'
-
 services:
   master:
     image: apache/seatunnel
@@ -275,6 +273,7 @@ services:
 
 networks:
   seatunnel_network:
+    name: seatunnel_network
     driver: bridge
     ipam:
       config:

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -240,7 +240,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -255,7 +255,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker2:
     image: apache/seatunnel
@@ -270,7 +270,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
 networks:
   seatunnel_network:
@@ -307,7 +307,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -322,7 +322,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   worker2:
     image: apache/seatunnel
@@ -337,7 +337,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
   ####
   ## add new worker node
@@ -355,7 +355,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network:
+      seatunnel_network
 
 networks:
   seatunnel_network:

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 The Dockerfile is like this:
 ```dockerfile
-FROM openjdk:8u342
+FROM seatunnelhub/openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image
@@ -240,7 +240,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -255,7 +255,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
@@ -270,7 +270,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
 networks:
   seatunnel_network:
@@ -307,7 +307,7 @@ services:
     ports:
       - "5801:5801"  
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
@@ -322,14 +322,14 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
     restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=- ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
@@ -337,7 +337,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
   ####
   ## add new worker node
@@ -355,7 +355,7 @@ services:
     depends_on:
       - master
     networks:
-      seatunnel_network
+      - seatunnel_network
 
 networks:
   seatunnel_network:

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -372,7 +372,6 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 #### use docker as a client
 - submit job (local):
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
@@ -382,7 +381,6 @@ docker run --name seatunnel_client \
 ```
 - submit job (cluster):
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
@@ -393,7 +391,6 @@ docker run --name seatunnel_client \
 
 - list job
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -361,6 +361,7 @@ services:
 
 networks:
   seatunnel_network:
+    name: seatunnel_network
     driver: bridge
     ipam:
       config:
@@ -378,8 +379,8 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    --network seatunnel_network \
+    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -c config/v2.batch.config.template
@@ -389,8 +390,8 @@ docker run --name seatunnel_client \
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    --network seatunnel_network \
+    -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 The Dockerfile is like this:
 ```dockerfile
-FROM openjdk:8
+FROM openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -274,7 +274,7 @@ services:
 
 networks:
   seatunnel_network:
-    name: seatunnel_network
+    name: seatunnel-network
     driver: bridge
     ipam:
       config:
@@ -361,7 +361,7 @@ services:
 
 networks:
   seatunnel_network:
-    name: seatunnel_network
+    name: seatunnel-network
     driver: bridge
     ipam:
       config:
@@ -379,7 +379,7 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel_network \
+    --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \
@@ -390,7 +390,7 @@ docker run --name seatunnel_client \
 ```shell
 # you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
-    --network seatunnel_network \
+    --network seatunnel-network \
     -e ST_DOCKER_MEMBER_LIST=172.16.0.2:5801 \
     --rm \
     apache/seatunnel \

--- a/versioned_docs/version-2.3.13/getting-started/docker/docker.md
+++ b/versioned_docs/version-2.3.13/getting-started/docker/docker.md
@@ -225,6 +225,7 @@ docker run -d --name seatunnel_worker_1 \
 
 The `docker-compose.yaml` file is :
 ```yaml
+
 services:
   master:
     image: apache/seatunnel
@@ -294,7 +295,6 @@ After that, you can use client or restapi to submit job to this cluster.
 If you want to increase cluster node, like add a new work node.
 
 ```yaml
-version: '3.8'
 
 services:
   master:


### PR DESCRIPTION
## Summary

This PR fixes three issues in the Docker setup documentation (`versioned_docs/version-2.3.13/getting-started/docker/docker.md`) that were introduced or left unresolved:

### 1. Fix service-level `networks` YAML syntax (high severity)

All service definitions used invalid bare-scalar syntax:
```yaml
# Before (invalid - parsed as string scalar by YAML)
networks:
  seatunnel_network

# After (correct list syntax)
networks:
  - seatunnel_network
```
The old syntax causes `docker compose config` to parse `networks` as a plain string instead of a mapping/list, which can cause startup failures with strict Docker Compose validators.

### 2. Fix worker2 environment variable typo in Scale section (high severity)

```yaml
# Before (broken - duplicate prefix)
- ST_DOCKER_MEMBER_LIST=- ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,...

# After (correct)
- ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
```
The typo caused worker2 to receive an invalid member list, preventing it from joining the cluster.

### 3. Replace `openjdk:8u342` with `seatunnelhub/openjdk:8u342`

The standalone `openjdk:8u342` tag is deprecated on Docker Hub. `seatunnelhub/openjdk:8u342` is the verified working alternative (digest confirmed).

## Test plan

- [x] `docker compose config` validates YAML syntax correctly (networks parsed as `seatunnel_network: null` mapping)
- [x] Cluster started with `docker compose up -d` - all 3 containers `Up`
- [x] Master logs confirmed `Members {size:3}` with both workers registered
- [x] `docker pull seatunnelhub/openjdk:8u342` succeeds (digest: sha256:86e863cc57215cfb181bd319736d0baf625fe8f150577f9eb58bd937f5452cb8)

Related: #443