### PR TITLE
[Doc] Add SeaTunnel Improvement Proposal (STIP) guide

### DIFF
--- a/community/contribution_guide/STIP.md
+++ b/community/contribution_guide/STIP.md
@@ -2,15 +2,15 @@
 
 ## What is a STIP?
 
-A **SeaTunnel Improvement Proposal (STIP)** is the standard process for
-proposing significant new features, architectural changes, or major improvements
-to Apache SeaTunnel. A STIP is tracked as a GitHub Issue with the `design` label
-and a sequential number prefix in its title (e.g., `[STIP-23] ...`).
+A **SeaTunnel Improvement Proposal (STIP)** is the standard process for proposing significant
+new features, architectural changes, or major improvements to Apache SeaTunnel. A STIP is
+tracked as a GitHub Issue with the `design` label and a sequential number prefix in its title
+(e.g., `[STIP-23] ...`).
 
-STIPs serve as the single source of truth for *why* a feature is being built,
-*how* it should be designed, and *what* the expected outcomes are. They give the
-community visibility into planned work, preserve a permanent record of design
-decisions, and help new contributors understand the direction of the project.
+STIPs serve as the single source of truth for *why* a feature is being built, *how* it should
+be designed, and *what* the expected outcomes are. They give the community visibility into
+planned work, preserve a permanent record of design decisions, and help new contributors
+understand the direction of the project.
 
 ## When Should I Create a STIP?
 
@@ -29,32 +29,54 @@ You do **not** need a STIP for:
 - Minor improvements or refactoring
 - Adding a new connector (unless it requires changes to the API or SPI)
 
+## STIP Lifecycle
+
+Each STIP goes through the following states:
+
+| State            | Meaning                                                                                      |
+|------------------|----------------------------------------------------------------------------------------------|
+| **Draft**        | The proposal is being written; not yet ready for community discussion.                       |
+| **Under Review** | The issue has been opened and is being discussed by the community on GitHub and/or the mailing list. |
+| **Accepted**     | The community has reached consensus and implementation may proceed.                          |
+| **Rejected**     | The community decided not to move forward with the proposal. The issue is closed with a clear explanation. |
+| **Implemented**  | The feature has been merged and the corresponding issue is closed.                           |
+
+A STIP author should update the issue with the current state as it progresses.
+
 ## STIP Numbering
 
-STIPs are numbered sequentially in the order they are created. To find the
-current highest number and determine the next one, check the full list:
+STIPs are numbered sequentially in the order they are created. To find the current highest
+number and determine the next one, browse the full list:
+
 > https://github.com/apache/seatunnel/issues?q=is%3Aissue+label%3Adesign+sort%3Acreated-asc
 
-Here are a few typical examples of STIPs for reference:
+Here are a few representative examples for reference:
 
-| Number  | Title                                                              | Issue                                                                 | Status |
-|---------|--------------------------------------------------------------------|-----------------------------------------------------------------------|--------|
-| STIP-1  | Decoupling connectors from compute engines                         | [#1608](https://github.com/apache/seatunnel/issues/1608)             | Closed |
-| STIP-5  | ST-Engine Design And Task Tracking                                 | [#2272](https://github.com/apache/seatunnel/issues/2272)             | Closed |
-| STIP-12 | CDC Connector Design                                               | [#3175](https://github.com/apache/seatunnel/issues/3175)             | Closed |
-| STIP-15 | Design of Dirty Data Collection                                    | [#4587](https://github.com/apache/seatunnel/issues/4587)             | Open   |
-| STIP-21 | Support Traffic Dyeing (Sampling) and Context-Aware Metrics        | [#10305](https://github.com/apache/seatunnel/issues/10305)           | Open   |
+| Number  | Title                                                              | Issue                                                                 | Status      |
+|---------|--------------------------------------------------------------------|-----------------------------------------------------------------------|-------------|
+| STIP-1  | Decoupling connectors from compute engines                         | [#1608](https://github.com/apache/seatunnel/issues/1608)             | Implemented |
+| STIP-5  | ST-Engine Design And Task Tracking                                 | [#2272](https://github.com/apache/seatunnel/issues/2272)             | Implemented |
+| STIP-12 | CDC Connector Design                                               | [#3175](https://github.com/apache/seatunnel/issues/3175)             | Implemented |
+| STIP-15 | Design of Dirty Data Collection                                    | [#4587](https://github.com/apache/seatunnel/issues/4587)             | Accepted    |
+| STIP-21 | Support Traffic Dyeing (Sampling) and Context-Aware Metrics        | [#10305](https://github.com/apache/seatunnel/issues/10305)           | Under Review|
 
-The next new proposal should follow sequentially, e.g., **STIP-23**.
+The next new proposal should be numbered **STIP-23**.
 
 ## How to Submit a STIP
 
-### Step 1 — Check the next available number
+### Step 1 — Gauge interest on the mailing list
 
-Browse the [full STIP list](https://github.com/apache/seatunnel/issues?q=is%3Aissue%20sort%3Acreated-desc%20STIP)
+Before opening a formal STIP, consider sending a short email to
+`dev@seatunnel.apache.org` describing the problem and your high-level approach.
+Early feedback helps you avoid investing time in a direction the community will
+not accept, and may reveal related efforts you were unaware of.
+
+### Step 2 — Find the next available number
+
+Browse the [full STIP list](https://github.com/apache/seatunnel/issues?q=is%3Aissue+label%3Adesign+sort%3Acreated-asc)
 to confirm the highest existing number and increment by one.
 
-### Step 2 — Open a GitHub Issue
+### Step 3 — Open a GitHub Issue
 
 Go to [apache/seatunnel Issues](https://github.com/apache/seatunnel/issues/new/choose)
 and create a new issue with:
@@ -62,3 +84,75 @@ and create a new issue with:
 - **Title:** `[STIP-N] [Module] Brief description`
   (e.g., `[STIP-23] [Connector] Support multi-catalog source`)
 - **Label:** `design`
+
+Write the issue body following the [STIP Content Template](#stip-content-template) below.
+
+### Step 4 — Drive the discussion to consensus
+
+Respond promptly to comments, update the proposal as the design evolves, and
+work toward one of the terminal states: **Accepted** or **Rejected**.
+Large or controversial proposals should be explicitly discussed on
+`dev@seatunnel.apache.org` before being marked Accepted.
+
+### Step 5 — Link PRs back to the STIP
+
+When submitting implementation pull requests, reference the STIP issue number
+in the PR description (e.g., `Closes #NNNN` or `Part of STIP-N`).
+
+## STIP Content Template
+
+Use the following structure when writing the body of your STIP GitHub Issue.
+Delete sections that are genuinely not applicable; do not leave them empty.
+
+```markdown
+## Background
+
+<!-- Describe the problem or opportunity this proposal addresses. Include
+     enough context for a reader unfamiliar with the area to understand why
+     this matters. -->
+
+## Motivation
+
+<!-- Explain why the current state is insufficient and why solving this
+     problem is valuable to the project. -->
+
+## Goals
+
+<!-- List the concrete outcomes this proposal aims to achieve. Use bullet
+     points, each starting with a verb:
+       - Support reading nested schemas from Kafka in the Kafka source.
+       - ...                                                          -->
+
+## Non-Goals
+
+<!-- Explicitly state what is out of scope for this proposal to prevent
+     scope creep during review. -->
+
+## Design
+
+<!-- Describe the proposed solution in enough detail that an experienced
+     contributor could implement it. Include:
+       - Key interfaces / APIs / configuration options being added or changed
+       - Data flow or sequence diagrams where helpful
+       - How the change interacts with existing components             -->
+
+## Compatibility, Deprecation, and Migration Plan
+
+<!-- Describe any backward-incompatible changes and how existing users
+     should migrate. If fully backward-compatible, state that explicitly. -->
+
+## Test Plan
+
+<!-- Describe how the change will be tested: unit tests, integration tests,
+     performance benchmarks, etc. -->
+
+## Alternatives Considered
+
+<!-- Describe other approaches you evaluated and explain why you chose the
+     proposed design over them. -->
+
+## References
+
+<!-- Links to related issues, PRs, papers, or prior art. -->
+```
+

--- a/community/contribution_guide/STIP.md
+++ b/community/contribution_guide/STIP.md
@@ -1,0 +1,64 @@
+# SeaTunnel Improvement Proposal (STIP)
+
+## What is a STIP?
+
+A **SeaTunnel Improvement Proposal (STIP)** is the standard process for
+proposing significant new features, architectural changes, or major improvements
+to Apache SeaTunnel. A STIP is tracked as a GitHub Issue with the `design` label
+and a sequential number prefix in its title (e.g., `[STIP-23] ...`).
+
+STIPs serve as the single source of truth for *why* a feature is being built,
+*how* it should be designed, and *what* the expected outcomes are. They give the
+community visibility into planned work, preserve a permanent record of design
+decisions, and help new contributors understand the direction of the project.
+
+## When Should I Create a STIP?
+
+Create a STIP when your proposal involves one or more of the following:
+
+- A new core feature or significant change to existing behavior
+- A change to the SeaTunnel API or Connector SPI
+- A new engine integration or major engine-level change
+- An architectural decision that affects multiple modules
+- A change that requires community consensus before implementation begins
+
+You do **not** need a STIP for:
+
+- Bug fixes
+- Documentation updates
+- Minor improvements or refactoring
+- Adding a new connector (unless it requires changes to the API or SPI)
+
+## STIP Numbering
+
+STIPs are numbered sequentially in the order they are created. To find the
+current highest number and determine the next one, check the full list:
+> https://github.com/apache/seatunnel/issues?q=is%3Aissue+label%3Adesign+sort%3Acreated-asc
+
+Here are a few typical examples of STIPs for reference:
+
+| Number  | Title                                                              | Issue                                                                 | Status |
+|---------|--------------------------------------------------------------------|-----------------------------------------------------------------------|--------|
+| STIP-1  | Decoupling connectors from compute engines                         | [#1608](https://github.com/apache/seatunnel/issues/1608)             | Closed |
+| STIP-5  | ST-Engine Design And Task Tracking                                 | [#2272](https://github.com/apache/seatunnel/issues/2272)             | Closed |
+| STIP-12 | CDC Connector Design                                               | [#3175](https://github.com/apache/seatunnel/issues/3175)             | Closed |
+| STIP-15 | Design of Dirty Data Collection                                    | [#4587](https://github.com/apache/seatunnel/issues/4587)             | Open   |
+| STIP-21 | Support Traffic Dyeing (Sampling) and Context-Aware Metrics        | [#10305](https://github.com/apache/seatunnel/issues/10305)           | Open   |
+
+The next new proposal should follow sequentially, e.g., **STIP-23**.
+
+## How to Submit a STIP
+
+### Step 1 — Check the next available number
+
+Browse the [full STIP list](https://github.com/apache/seatunnel/issues?q=is%3Aissue%20sort%3Acreated-desc%20STIP)
+to confirm the highest existing number and increment by one.
+
+### Step 2 — Open a GitHub Issue
+
+Go to [apache/seatunnel Issues](https://github.com/apache/seatunnel/issues/new/choose)
+and create a new issue with:
+
+- **Title:** `[STIP-N] [Module] Brief description`
+  (e.g., `[STIP-23] [Connector] Support multi-catalog source`)
+- **Label:** `design`

--- a/community/contribution_guide/STIP.md
+++ b/community/contribution_guide/STIP.md
@@ -83,7 +83,6 @@ and create a new issue with:
 
 - **Title:** `[STIP-N] [Module] Brief description`
   (e.g., `[STIP-23] [Connector] Support multi-catalog source`)
-- **Label:** `design`
 
 Write the issue body following the [STIP Content Template](#stip-content-template) below.
 

--- a/community/contribution_guide/contribute.md
+++ b/community/contribution_guide/contribute.md
@@ -87,6 +87,10 @@ accompanied by detail, such as a design document and/or code change. Large new c
 should consider be discussed on the mailing list first.
 Feature requests may be rejected, or closed after a long period of inactivity.
 
+For significant new features or architectural changes, consider opening a
+[SeaTunnel Improvement Proposal (STIP)](./STIP.md) before starting implementation.
+STIPs provide a structured way to gain community consensus and preserve design decisions.
+
 ## Contributing to ISSUE maintenance
 
 Given the sheer volume of issues raised in the Apache SeaTunnel ISSUE, inevitably some issues are
@@ -279,6 +283,8 @@ decisions are discussed in ISSUE.
     1. Do not include a patch file; pull requests are used to propose the actual change.
 1. If the change is a large change, consider inviting discussion on the issue at
    `dev@seatunnel.apache.org` first before proceeding to implement the change.
+   For architectural changes or new API/SPI surface, a
+   [SeaTunnel Improvement Proposal (STIP)](./STIP.md) is strongly recommended.
 
 ### Pull request
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/STIP.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/STIP.md
@@ -1,0 +1,143 @@
+# SeaTunnel 改进提案（STIP）
+
+## 什么是 STIP？
+
+**SeaTunnel 改进提案（SeaTunnel Improvement Proposal，简称 STIP）** 是向 Apache SeaTunnel
+提出重大新功能、架构变更或重要改进的标准流程。每个 STIP 以 GitHub Issue 的形式存在，Issue
+标题带有递增的序号前缀（例如 `[STIP-23] ...`）。
+
+STIP 是记录"为什么要做这个功能"、"应该如何设计"以及"预期产出是什么"的唯一可信来源。它让社区对
+计划中的工作保持可见性，留下设计决策的永久记录，帮助新贡献者了解项目的发展方向。
+
+## 什么时候需要创建 STIP？
+
+当你的提案涉及以下一项或多项时，请创建 STIP：
+
+- 新的核心功能，或对现有行为的重大变更
+- 对 SeaTunnel API 或 Connector SPI 的修改
+- 新的引擎集成，或引擎层面的重大变更
+- 影响多个模块的架构决策
+- 需要社区达成共识才能开始实施的变更
+
+以下情况**不需要** STIP：
+
+- Bug 修复
+- 文档更新
+- 小幅改进或重构
+- 新增连接器（除非涉及 API 或 SPI 的改动）
+
+## STIP 的生命周期
+
+每个 STIP 会经历以下状态：
+
+| 状态              | 含义                                                                                      |
+|-----------------|-------------------------------------------------------------------------------------------|
+| **草稿（Draft）**   | 提案正在撰写中，尚未准备好供社区讨论。                                                         |
+| **审议中（Under Review）** | Issue 已开启，社区正在 GitHub 和/或邮件列表上讨论。                                        |
+| **已接受（Accepted）** | 社区已达成共识，可以开始实施。                                                               |
+| **已拒绝（Rejected）** | 社区决定不推进该提案，Issue 已关闭并附有明确说明。                                           |
+| **已实现（Implemented）** | 功能已合并，对应 Issue 已关闭。                                                           |
+
+提案作者应在提案推进过程中及时更新 Issue 的当前状态。
+
+## STIP 编号规则
+
+STIP 按创建顺序依次编号。要确认当前最大编号并计算下一个编号，请浏览完整列表：
+
+> https://github.com/apache/seatunnel/issues?q=is%3Aissue+label%3Adesign+sort%3Acreated-asc
+
+以下是几个有代表性的参考示例：
+
+| 编号     | 标题                                                               | Issue                                                                 | 状态         |
+|---------|--------------------------------------------------------------------|-----------------------------------------------------------------------|--------------|
+| STIP-1  | 将连接器与计算引擎解耦                                                | [#1608](https://github.com/apache/seatunnel/issues/1608)             | 已实现        |
+| STIP-5  | ST-Engine 设计与任务跟踪                                              | [#2272](https://github.com/apache/seatunnel/issues/2272)             | 已实现        |
+| STIP-12 | CDC 连接器设计                                                       | [#3175](https://github.com/apache/seatunnel/issues/3175)             | 已实现        |
+| STIP-15 | 脏数据收集设计                                                        | [#4587](https://github.com/apache/seatunnel/issues/4587)             | 已接受        |
+| STIP-21 | 支持流量染色（采样）与上下文感知指标                                      | [#10305](https://github.com/apache/seatunnel/issues/10305)           | 审议中        |
+
+下一个新提案应编号为 **STIP-23**。
+
+## 如何提交 STIP
+
+### 第一步 — 在邮件列表预沟通
+
+在正式开启 STIP 之前，建议先向 `dev@seatunnel.apache.org`
+发一封简短的邮件，描述你要解决的问题及大致思路。
+提前获取反馈有助于避免在社区不会接受的方向上浪费时间，也可能发现你尚不了解的相关工作。
+
+### 第二步 — 确认下一个可用编号
+
+浏览 [STIP 完整列表](https://github.com/apache/seatunnel/issues?q=is%3Aissue+label%3Adesign+sort%3Acreated-asc)，
+确认当前最大编号，加一即为新编号。
+
+### 第三步 — 开启 GitHub Issue
+
+前往 [apache/seatunnel Issues](https://github.com/apache/seatunnel/issues/new/choose)，
+创建一个新 Issue，要求：
+
+- **标题：** `[STIP-N] [模块] 简短描述`
+  （例如：`[STIP-23] [Connector] 支持多 Catalog 数据源`）
+
+按照下方的 [STIP 内容模板](#stip-内容模板) 填写 Issue 正文。
+
+### 第四步 — 推动讨论达成共识
+
+及时回复评论，随设计演进更新提案，最终推动提案进入终态：**已接受** 或 **已拒绝**。
+对于影响范围较大或存在争议的提案，建议在标记为"已接受"之前先在
+`dev@seatunnel.apache.org` 上进行显式讨论。
+
+### 第五步 — 在 PR 中关联 STIP
+
+提交实现 PR 时，在 PR 描述中引用 STIP Issue 编号
+（例如 `Closes #NNNN` 或 `Part of STIP-N`）。
+
+## STIP 内容模板
+
+创建 STIP Issue 时，请使用以下结构填写正文。
+不适用的章节可删除，但不要留空。
+
+```markdown
+## 背景（Background）
+
+<!-- 描述本提案要解决的问题或机会。提供足够的上下文，使不熟悉该领域的
+     读者也能理解其重要性。 -->
+
+## 动机（Motivation）
+
+<!-- 说明当前状态为何不足，以及解决这个问题对项目的价值所在。 -->
+
+## 目标（Goals）
+
+<!-- 列出本提案希望达成的具体结果，每条以动词开头：
+       - 支持在 Kafka Source 中读取嵌套 Schema
+       - ...                                    -->
+
+## 非目标（Non-Goals）
+
+<!-- 明确说明本提案不打算覆盖的范围，防止评审过程中出现范围蔓延。 -->
+
+## 设计方案（Design）
+
+<!-- 以足够的细节描述提议的解决方案，使有经验的贡献者能够据此实施。包括：
+       - 新增或修改的关键接口 / API / 配置项
+       - 必要时提供数据流图或时序图
+       - 与现有组件的交互方式                            -->
+
+## 兼容性、废弃与迁移计划（Compatibility, Deprecation, and Migration Plan）
+
+<!-- 描述任何不向后兼容的变更，以及现有用户应如何迁移。
+     若完全向后兼容，请明确声明。 -->
+
+## 测试计划（Test Plan）
+
+<!-- 说明如何对本次变更进行测试：单元测试、集成测试、性能基准等。 -->
+
+## 备选方案（Alternatives Considered）
+
+<!-- 描述你评估过的其他方案，并解释为何最终选择了本提案的设计。 -->
+
+## 参考资料（References）
+
+<!-- 相关 Issue、PR、论文或已有工作的链接。 -->
+```


### PR DESCRIPTION
## Summary

This PR introduces a dedicated STIP (SeaTunnel Improvement Proposal) guide to formalize the process for proposing significant features and architectural changes to Apache SeaTunnel.

## Changes

### New files
- `community/contribution_guide/STIP.md` — English STIP guide
- `i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/STIP.md` — Chinese translation

### Modified files
- `community/contribution_guide/contribute.md` — Added two cross-references to the STIP guide at natural points where large changes are discussed

## What the STIP guide covers

- **What is a STIP** and when to create one (vs. when not to)
- **STIP lifecycle** with clearly defined states (Draft → Under Review → Accepted/Rejected → Implemented)
- **STIP numbering** with representative examples from STIP-1 through STIP-21
- **5-step submission process**: mailing list preview → find next number → open GitHub Issue → drive consensus → link PRs
- **STIP content template** with all standard sections (Background, Motivation, Goals, Non-Goals, Design, Compatibility, Test Plan, Alternatives, References)

This brings the SeaTunnel contribution workflow guidance in line with similar processes in other Apache projects (e.g., Flink's FLIP, Kafka's KIP).