### PR TITLE
[Docs] Update SeaTunnel PMC member list

### DIFF
--- a/src/pages/team/languages.json
+++ b/src/pages/team/languages.json
@@ -143,6 +143,12 @@
       "githubId": "liunaijie",
       "name": "Naijie Liu",
       "userId": "28497357"
+    },
+    {
+      "apacheId": "shenghang",
+      "githubId": "zhangshenghang",
+      "name": "Shenghang Zhang",
+      "userId": "29418975"
     }
   ],
   "committer": [
@@ -211,12 +217,6 @@
       "githubId": "arshadmohammad",
       "name": "Mohammad Arshad",
       "userId": "5720433"
-    },
-    {
-      "apacheId": "shenghang",
-      "githubId": "zhangshenghang",
-      "name": "Shenghang Zhang",
-      "userId": "29418975"
     },
     {
       "apacheId": "zhangdonghao",


### PR DESCRIPTION
### Purpose of this pull request
Update the SeaTunnel website team page data to move Shenghang Zhang (`shenghang` / `zhangshenghang`) from the committer list to the PMC list.

### Does this PR introduce any user-facing change?
Yes. The website team page will list Shenghang Zhang under PMC instead of Committer.

### How was this patch tested?
- `node -e "const data=require('./src/pages/team/languages.json'); const pmc=data.pmc.filter(m=>m.apacheId==='shenghang'); const committer=data.committer.filter(m=>m.apacheId==='shenghang'); console.log({pmc:pmc.length, committer:committer.length, member:pmc[0]}); if (pmc.length !== 1 || committer.length !== 0) process.exit(1);"`
- `git diff --check`
- `./tools/build-docs.sh`

Additional notes:
- `npm run build` currently fails after docs sync with `Module not found: Error: Can't resolve '../../../docs/images/icons' in 'src/theme/DocCard'`, which appears unrelated to this JSON-only team member update.
- `npm run typecheck` currently fails while parsing existing `docusaurus.config.js` / dependency declarations, also unrelated to this change.