### PR TITLE
[Doc] Clarify code review approval policy for dev PRs

### DIFF
--- a/community/contribution_guide/code-review.md
+++ b/community/contribution_guide/code-review.md
@@ -1,17 +1,28 @@
 # Code Review Guidance
 
-In order to continuously improve the quality of Apache SeaTunnel code, we have compiled a code review guide.
+To continuously improve the quality of Apache SeaTunnel code, we have compiled this code review guide.
 
-We hope that code reviewers strictly adhere to this guidance, especially in terms of document and e2e inspections.
+We expect reviewers and committers to follow this guidance consistently, especially for documentation, e2e coverage, and compatibility-sensitive changes.
 
-1. Is the title of PR in compliance with regulations and the correct expression of meaning
-2. Is there any issue link related to bugs in the description of PR, and is there a design document link for major modifications.
-3. Check if documents have been added/changed, and if the document description is correct. A good example is https://github.com/apache/seatunnel/pull/4590
-4. Check whether to add e2e and the correctness of e2e test (function coverage and result data validation, including whether to cover all supported data types, check whether the columns between the source and target should be aligned, the number of rows should be aligned, and the data in each row should also be aligned). A good example is https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e
-5. Check if there are any incompatible changes (especially modifications to parameters, with special attention paid. If incompatible changes are indeed needed, they need to be discussed by email)
-6. Check CI results, license updates, etc
-7. Enumerator update, check if the split snapshot and restore are correct, including whether the split allocation strategy is stable
-8. Reader update, check split snapshot and checkpoint lock range and various end conditions in pollnext
-9. Sink update, check for two-stage submission of XXXCommitter (if any)
-10. Writer updates, checking data refresh frequency, interval, memory like batch size, etc
-11. After passing the above functional checks, please review the code style (ensuring that the functionality is based on the code style), and the style is related to personal preferences. You can also refer to this: https://shardingsphere.apache.org/community/cn/involved/conduct/code/
+## Approval policy for PRs targeting `dev`
+
+GitHub currently shows the `dev` branch as requiring only one approval before merge. This is only the global branch protection baseline.
+
+By community consensus, PRs that modify core modules still require **two committer approvals** before merge. GitHub cannot enforce this per-module rule automatically today, so reviewers and committers must inspect the changed files manually. If a PR touches core modules but does not yet have two committer approvals, do not merge it even if GitHub reports that the required review check has passed.
+
+## General review checklist
+
+1. Check whether the PR title follows project conventions and accurately describes the change.
+2. Check whether bug fixes link the related issue, and whether major changes link a design document.
+3. Check whether documentation has been added or updated when needed, and whether the documentation is correct. A good example is [PR #4590](https://github.com/apache/seatunnel/pull/4590).
+4. Check whether e2e tests should be added, and whether the e2e coverage is correct. Review both function coverage and result validation, including supported data types, source and target column alignment, row counts, and row-level data correctness. A good example is the [ClickHouse e2e case](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e).
+5. Check whether the change introduces incompatible behavior, especially parameter changes. If an incompatible change is really necessary, it should be discussed on the mailing list first.
+6. Check CI results, license updates, and other release-readiness signals.
+
+## Component-specific review checklist
+
+7. For enumerator changes, check whether split snapshot and restore are correct, and whether the split allocation strategy remains stable.
+8. For reader changes, check split snapshot handling, checkpoint lock scope, and all end conditions in `pollNext`.
+9. For sink changes, check whether two-phase commit logic in `XXXCommitter` (if any) is still correct.
+10. For writer changes, check data flush frequency, flush interval, memory usage, batch size, and other resource-sensitive behavior.
+11. After the functional checks above pass, review the code style. Code style should support readability without weakening functional correctness. For additional style references, see [ShardingSphere's code conduct guide](https://shardingsphere.apache.org/community/cn/involved/conduct/code/).

--- a/community/contribution_guide/code-review.md
+++ b/community/contribution_guide/code-review.md
@@ -8,7 +8,27 @@ We expect reviewers and committers to follow this guidance consistently, especia
 
 GitHub currently shows the `dev` branch as requiring only one approval before merge. This is only the global branch protection baseline.
 
-By community consensus, PRs that modify core modules still require **two committer approvals** before merge. GitHub cannot enforce this per-module rule automatically today, so reviewers and committers must inspect the changed files manually. If a PR touches core modules but does not yet have two committer approvals, do not merge it even if GitHub reports that the required review check has passed.
+For PRs that **do not** touch core modules, the merge baseline is:
+
+1. **One committer approval**
+2. Passing automated bot checks, such as CI, code style, and license validation
+3. At least one collaborator or AI bot review, where applicable
+
+The following modules are considered core and therefore still require **two committer approvals** before merge:
+
+- `seatunnel-api`
+- `seatunnel-engine/seatunnel-engine-core`
+- `seatunnel-engine/seatunnel-engine-server`
+- `seatunnel-engine/seatunnel-engine-client`
+- `seatunnel-engine/seatunnel-engine-common`
+- `seatunnel-engine/seatunnel-engine-serializer`
+- `seatunnel-engine/seatunnel-engine-storage`
+
+All other modules, including connectors, transforms, e2e tests, documentation, and tooling, follow the relaxed baseline above as long as they do not modify any of the core modules listed here.
+
+This policy is determined by **module scope**, not by the number of changed files or lines of code. If a PR touches any core module, the stricter **two committer approvals** rule applies to the whole PR.
+
+GitHub cannot enforce this per-module rule automatically today, so reviewers and committers must inspect the changed files manually. If a PR touches core modules but does not yet have two committer approvals, do not merge it even if GitHub reports that the required review check has passed.
 
 ## General review checklist
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/code-review.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/code-review.md
@@ -1,0 +1,48 @@
+# 代码评审指南
+
+为了持续提升 Apache SeaTunnel 的代码质量，我们整理了这份代码评审指南。
+
+我们希望 reviewer 和 committer 在评审过程中持续遵循这些要求，尤其是在文档、e2e 覆盖以及兼容性敏感改动方面。
+
+## 面向 `dev` 分支 PR 的审批规则
+
+GitHub 当前展示的 `dev` 分支合并门槛是只需要 1 个 approval。但这只是全局分支保护的基础要求。
+
+对于**不涉及 core 模块**的 PR，合并基线为：
+
+1. **1 个 committer approval**
+2. 自动化检查通过，例如 CI、代码风格检查和许可证校验
+3. 在适用的情况下，至少有 1 个 collaborator 或 AI bot review
+
+以下模块被视为 core 模块，因此仍然要求 **2 个 committer approvals** 后才能合并：
+
+- `seatunnel-api`
+- `seatunnel-engine/seatunnel-engine-core`
+- `seatunnel-engine/seatunnel-engine-server`
+- `seatunnel-engine/seatunnel-engine-client`
+- `seatunnel-engine/seatunnel-engine-common`
+- `seatunnel-engine/seatunnel-engine-serializer`
+- `seatunnel-engine/seatunnel-engine-storage`
+
+其他模块，包括 connectors、transforms、e2e tests、documentation 和 tooling，只要没有修改上面列出的任何 core 模块，就遵循前面的放宽基线。
+
+这条规则按**模块范围**判断，而不是按修改文件数或代码行数判断。只要一个 PR 触及任意 core 模块，整条 PR 就必须遵循 **2 个 committer approvals** 的更严格规则。
+
+由于 GitHub 当前还不能自动按模块范围强制执行这条规则，因此 reviewer 和 committer 需要手动检查改动文件。如果一个 PR 触及了 core 模块，但还没有拿到 2 个 committer approvals，即使 GitHub 显示 review check 已经通过，也不要合并。
+
+## 通用评审检查项
+
+1. 检查 PR 标题是否符合项目规范，是否准确表达了改动内容。
+2. 检查 bug 修复类 PR 是否关联了对应 issue，重大改动是否附带了设计文档。
+3. 检查是否需要补充或更新文档，以及文档内容是否正确。一个较好的参考示例是 [PR #4590](https://github.com/apache/seatunnel/pull/4590)。
+4. 检查是否需要补充 e2e 测试，以及 e2e 覆盖是否正确。这里不仅要看功能覆盖，还要看结果校验是否充分，包括支持的数据类型、源端和目标端字段对齐、行数对齐，以及逐行数据内容是否正确。一个较好的参考示例是 [ClickHouse e2e 用例](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e)。
+5. 检查这次改动是否引入了不兼容行为，尤其是参数变更。如果确实需要做不兼容改动，应先通过邮件列表讨论。
+6. 检查 CI 结果、许可证更新以及其他发布准备信号。
+
+## 组件维度评审检查项
+
+7. 对于 enumerator 改动，要检查 split snapshot 和 restore 是否正确，以及 split 分配策略是否仍然稳定。
+8. 对于 reader 改动，要检查 split snapshot 处理、checkpoint lock 的作用范围，以及 `pollNext` 中的各种结束条件。
+9. 对于 sink 改动，要检查 `XXXCommitter`（如果存在）中的两阶段提交逻辑是否仍然正确。
+10. 对于 writer 改动，要检查数据刷新频率、刷新间隔、内存占用、batch size 以及其他资源敏感行为。
+11. 在以上功能性检查通过后，再检查代码风格。代码风格应当服务于可读性，但不能削弱功能正确性。更多风格参考可见 [ShardingSphere 的代码规范说明](https://shardingsphere.apache.org/community/cn/involved/conduct/code/)。


### PR DESCRIPTION
## What
- clarify the relaxed merge baseline for PRs that do not touch core modules
- document the exact core module list that still requires 2 committer approvals
- explain that the policy is determined by module scope, not by file-count or line-count thresholds
- state that this rule must currently be enforced manually during review and merge
- reorganize the code review page into approval policy, general checks, and component-specific checks

## Why
- the mailing list discussion accepted a more relaxed review path for non-core changes on `dev`
- the previous draft only documented the stricter rule for core modules and did not yet capture the full non-core baseline or the scope-based decision rule
- documenting the accepted policy in one place helps reviewers apply the same standard consistently

## Discussion thread
- https://lists.apache.org/thread/wqpsjzodzslzt47527gc52bvgd6dqy7d

## Validation
- reviewed and updated only `community/contribution_guide/code-review.md`
- `git diff --check`
- `npm run sync`
- attempted `npm run build` after sync; the build continued to surface existing historical SVG asset warnings in the repository, so I am not claiming a full clean build result from this change
