### PR TITLE
[Fix] Allow Google Translate runtime CSP host

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,11 @@
 ErrorDocument 404 /404.html
 
 <IfModule mod_headers.c>
+    # Google Translate issues a follow-up JSONP request to translate-pa.googleapis.com
+    # after a user chooses a non-native language from the navbar dropdown.
     Header set Content-Security-Policy "default-src 'self' data: blob: *.apache.org *.kapa.ai *.githubusercontent.com *.googleapis.com *.google.com *.run.app *.gstatic.com *.github.com https://hcaptcha.com https://*.hcaptcha.com *.apachecon.com *.communityovercode.org 'unsafe-inline' 'unsafe-eval'; \
-script-src 'self' 'unsafe-inline' 'unsafe-eval' widget.kapa.ai www.google.com translate.google.com translate.googleapis.com https://hcaptcha.com https://*.hcaptcha.com https://www.gstatic.com; \
-connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai *.algolia.net *.algolianet.com https://hcaptcha.com https://*.hcaptcha.com www.google.com translate.googleapis.com; \
+script-src 'self' 'unsafe-inline' 'unsafe-eval' widget.kapa.ai www.google.com translate.google.com translate.googleapis.com translate-pa.googleapis.com https://hcaptcha.com https://*.hcaptcha.com https://www.gstatic.com; \
+connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai *.algolia.net *.algolianet.com https://hcaptcha.com https://*.hcaptcha.com www.google.com translate.googleapis.com translate-pa.googleapis.com; \
 frame-src 'self' * www.google.com https://hcaptcha.com https://*.hcaptcha.com; \
 frame-ancestors 'self' *.google.com; \
 worker-src 'self' data: blob:; \


### PR DESCRIPTION
## What changed
- allow the Google Translate runtime domain `translate-pa.googleapis.com` in the website CSP
- keep the change scoped to `.htaccess` only and add a short comment documenting why the domain is needed

## Why it changed
- non-English/non-Chinese languages on `seatunnel.apache.org` use Google Translate rather than native Docusaurus locales
- after a user picked Japanese, Korean, French, Spanish, Russian, or German, the page wrote the `googtrans` cookie but the browser blocked a follow-up request to `translate-pa.googleapis.com`
- that CSP block prevented the translated content from being applied, so only English and Chinese appeared to work

## Impact
- the additional languages in the navbar dropdown now translate page content again instead of silently failing after selection
- the fix is limited to the CSP allowlist and does not change the existing locale dropdown logic

## Validation
- reproduced the failure in the browser: cookie updated but page text stayed unchanged while CSP blocked `translate-pa.googleapis.com`
- re-verified locally through a proxy that served the patched CSP header: selecting non-native languages translated the homepage body text and page title, and switching back to `English` still worked

## 中文说明
### 改动内容
- 在网站 CSP 中放行 Google Translate 运行时依赖域名 `translate-pa.googleapis.com`
- 改动只落在 `.htaccess`，并补充了简短注释说明这个域名为什么需要放开

### 根因说明
- `seatunnel.apache.org` 上，英文和中文是 Docusaurus 原生 locale，其余语言依赖 Google Translate
- 用户点击日语、韩语、法语、西班牙语、俄语、德语后，页面虽然写入了 `googtrans` cookie，但浏览器继续请求 `translate-pa.googleapis.com` 时被 CSP 拦截
- 因为这条后续请求被拦截，翻译结果没有真正应用到页面正文，所以表现成“只有英文和中文正常，其他语言切换无效”

### 影响范围
- 导航栏中的这些附加语言现在可以重新翻译页面内容，而不是只记录语言选择却不生效
- 本次修复仅调整 CSP 白名单，不修改现有语言下拉和原生 locale 逻辑

### 验证结果
- 已在浏览器中复现原问题：`googtrans` cookie 更新，但正文不变，同时控制台出现 `translate-pa.googleapis.com` 的 CSP 拦截报错
- 已通过带修复后 CSP 头的本地代理重新验证：首页标题和正文可以随目标语言切换，且切回 `English` 也正常

## Approval note
- For this repository, the checked-in `.asf.yaml` currently declares `required_approving_review_count: 1` for `main`.
- I also verified that this PR is already in `APPROVED` state with one approval.
- If reviewers ask for 2 approvals, that should be treated as an additional maintainer/review expectation rather than a GitHub requirement I could verify from the repository configuration in this checkout.
