### PR TITLE
[Hotfix] Fix Google Translate language switching across non-native locales

### DIFF
--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
@@ -22,6 +22,42 @@ const GOOGLE_LANGUAGES = [
     { label: 'Deutsch', code: 'de' },
 ];
 
+/**
+ * Google Translate may persist the same cookie on multiple domain scopes
+ * such as the host, the parent domain, and the current page host-only scope.
+ * Enumerating all reachable variants lets us clear stale cookies before
+ * writing the next target language.
+ */
+function getGoogleTranslateCookieDomains(hostname) {
+    if (!hostname || hostname === 'localhost' || hostname === '127.0.0.1') {
+        return [''];
+    }
+
+    const domains = new Set(['', hostname, `.${hostname}`]);
+    const parts = hostname.split('.').filter(Boolean);
+
+    for (let index = 1; index < parts.length - 1; index += 1) {
+        const parentDomain = parts.slice(index).join('.');
+        if (!parentDomain.includes('.')) {
+            continue;
+        }
+        domains.add(parentDomain);
+        domains.add(`.${parentDomain}`);
+    }
+
+    return Array.from(domains);
+}
+
+function writeGoogleTranslateCookie(name, value, hostname, expires) {
+    const domainCandidates = getGoogleTranslateCookieDomains(hostname);
+
+    domainCandidates.forEach((domain) => {
+        const domainAttribute = domain ? `; domain=${domain}` : '';
+        const expiresAttribute = expires ? `; expires=${expires}` : '';
+        document.cookie = `${name}=${value}${expiresAttribute}; path=/${domainAttribute}`;
+    });
+}
+
 export default function LocaleDropdownNavbarItem({
     mobile,
     dropdownItemsBefore,
@@ -37,11 +73,18 @@ export default function LocaleDropdownNavbarItem({
     // Helper function to get current Google Translate language code from cookie
     const getGoogleTranslateLangCode = () => {
         if (typeof document === 'undefined') return null;
-        const cookie = document.cookie.split('; ').find(row => row.startsWith('googtrans='));
-        if (cookie) {
-            const match = cookie.match(/googtrans=\/[^\/]+\/([^;]+)/);
-            return match ? match[1] : null;
+
+        const cookies = document.cookie
+            .split('; ')
+            .filter((row) => row.startsWith('googtrans='));
+
+        for (let index = cookies.length - 1; index >= 0; index -= 1) {
+            const match = cookies[index].match(/googtrans=\/[^\/]+\/([^;]+)/);
+            if (match) {
+                return match[1];
+            }
         }
+
         return null;
     };
 
@@ -87,16 +130,9 @@ export default function LocaleDropdownNavbarItem({
 
     // Helper function to trigger Google Translate programmatically
     const handleGoogleTranslate = (langCode) => {
-        // Set Google Translate cookie
         const cookieValue = '/en/' + langCode;
-
-        // Set cookie without domain for localhost compatibility
-        document.cookie = 'googtrans=' + cookieValue + '; path=/';
-
-        // Also set with domain if not localhost
-        if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
-            document.cookie = 'googtrans=' + cookieValue + '; path=/; domain=' + window.location.hostname;
-        }
+        writeGoogleTranslateCookie('googtrans', '', window.location.hostname, 'Thu, 01 Jan 1970 00:00:00 UTC');
+        writeGoogleTranslateCookie('googtrans', cookieValue, window.location.hostname);
 
         // If currently on a /zh-CN/ page, redirect to English version first
         const currentPath = window.location.pathname;
@@ -131,15 +167,7 @@ export default function LocaleDropdownNavbarItem({
             autoAddBaseUrl: false,
             className: `notranslate ${isActive ? activeClass : ''}`.trim(),
             onClick: () => {
-                // Clear Google Translate cookies when switching to native locales
-                const clearCookie = (name) => {
-                    document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-                    document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/seatunnel-website;';
-                    if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
-                        document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; domain=.' + window.location.hostname + '; path=/;';
-                    }
-                };
-                clearCookie('googtrans');
+                writeGoogleTranslateCookie('googtrans', '', window.location.hostname, 'Thu, 01 Jan 1970 00:00:00 UTC');
                 // Update the label immediately
                 setCurrentLangLabel(localeConfigs[locale].label);
             }


### PR DESCRIPTION
## What changed

This PR fixes Google Translate language switching for non-native locales in the website navbar.

## Root cause

After switching to a Google-translated language such as Japanese, the site could no longer switch correctly to another translated language such as French or German.

The root cause was that `googtrans` cookies could exist at multiple domain scopes at the same time, including:

- `seatunnel.apache.org`
- `.seatunnel.apache.org`
- `.apache.org`

The previous implementation wrote a new cookie but did not clear all stale variants first. As a result, the page could keep reading an older language value and remain stuck on the previous translation.

## Fix

This change:

- enumerates all reachable `googtrans` cookie domain variants for the current hostname
- clears all stale `googtrans` cookies before writing the new target language
- reads the current translated language from the last effective cookie value to keep the navbar label in sync with the active translation state

## Impact

Users can now switch repeatedly between Google-translated languages from the navbar, for example:

- `English -> 日本語 -> Français`
- `English -> 日本語 -> Deutsch`
- `简体中文 -> 日本語 -> Français`

## Validation

- `git diff --check`
- started a local dev server with `npm run start -- --host 127.0.0.1 --port 3002`
- verified locally that `English -> 日本語 -> Français` switches correctly and the final page state becomes French
- reproduced the stale-cookie failure mode against the production site and confirmed the fix logic resolves it by clearing all domain-scoped `googtrans` cookie variants before applying the next language
