### PR TITLE
docs: update 2.3.13 about wording

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/introduction/about.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/introduction/about.md
@@ -41,7 +41,7 @@ SeaTunnel的运行流程如上图所示。
 
 Source Connector负责并行读取数据并将数据发送到下游Transform或直接发送到Sink，Sink将数据写入目的地。 值得注意的是，Source、Transform 和 Sink 可以很容易地自行开发和扩展。
 
-SeaTunnel 是一个 EL(T) 数据集成平台。 因此，在SeaTunnel中，Transform只能用于对数据进行一些简单的转换，例如将一列的数据转换为大写或小写，更改列名，或者将一列拆分为多列。
+SeaTunnel 是一个 EL(T) 数据集成工具。 因此，在SeaTunnel中，Transform只能用于对数据进行一些简单的转换，例如将一列的数据转换为大写或小写，更改列名，或者将一列拆分为多列。
 
 SeaTunnel 使用的默认引擎是 [SeaTunnel Engine](../engines/zeta/about.md)。 如果您选择使用Flink或Spark引擎，SeaTunnel会将Connector打包成Flink或Spark程序并提交给Flink或Spark运行。
 

--- a/versioned_docs/version-2.3.13/introduction/about.md
+++ b/versioned_docs/version-2.3.13/introduction/about.md
@@ -43,7 +43,7 @@ The user configures the job information and selects the execution engine to subm
 
 The Source Connector is responsible for parallel reading and sending the data to the downstream Transform or directly to the Sink, and the Sink writes the data to the destination. It is worth noting that Source, Transform and Sink can be easily developed and extended by yourself.
 
-SeaTunnel is an EL(T) data integration platform. Therefore, in SeaTunnel, Transform can only be used to perform some simple transformations on data, such as converting the data of a column to uppercase or lowercase, changing the column name, or splitting a column into multiple columns.
+SeaTunnel is an EL(T) data integration tool. Therefore, in SeaTunnel, Transform can only be used to perform some simple transformations on data, such as converting the data of a column to uppercase or lowercase, changing the column name, or splitting a column into multiple columns.
 
 The default engine use by SeaTunnel is [SeaTunnel Engine](../engines/zeta/about.md). If you choose to use the Flink or Spark engine, SeaTunnel will package the Connector into a Flink or Spark program and submit it to Flink or Spark to run.
 


### PR DESCRIPTION
## Summary
- update the 2.3.13 About page wording in both Chinese and English from `platform` / `平台` to `tool` / `工具`
- keep the scope limited to the two versioned About documents only

## Changed Files
- `i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/introduction/about.md`
- `versioned_docs/version-2.3.13/introduction/about.md`

## Validation
- skipped actual preview/runtime verification in this update because the user explicitly said this is only a doc description PR and no actual verification is required
