### PR TITLE
[Docs] Localize Chinese docs sidebar headings

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -116,7 +116,7 @@
     "description": "The generated-index page title for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Transforms.link.generated-index.description": {
-    "message": "List all transforms supported by Apache SeaTunnel.",
+    "message": "查看 Apache SeaTunnel 支持的全部数据转换能力，并按场景选择合适的转换插件。",
     "description": "The generated-index page description for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Engines": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -4,19 +4,19 @@
     "description": "The label for version current"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Configuration": {
-    "message": "配置",
+    "message": "基础配置",
     "description": "The label for category Configuration in sidebar docs"
   },
   "sidebar.docs.category.Architecture": {
-    "message": "架构",
+    "message": "架构与原理",
     "description": "The label for category Architecture in sidebar docs"
   },
   "sidebar.docs.category.API Design": {
@@ -24,27 +24,27 @@
     "description": "The label for category API Design in sidebar docs"
   },
   "sidebar.docs.category.Engine": {
-    "message": "引擎",
+    "message": "引擎原理",
     "description": "The label for category Engine in sidebar docs"
   },
   "sidebar.docs.category.Fault Tolerance": {
-    "message": "容错",
+    "message": "容错机制",
     "description": "The label for category Fault Tolerance in sidebar docs"
   },
   "sidebar.docs.category.Features": {
-    "message": "特性",
+    "message": "关键特性",
     "description": "The label for category Features in sidebar docs"
   },
   "sidebar.docs.category.Getting Started": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Getting Started in sidebar docs"
   },
   "sidebar.docs.category.Locally": {
-    "message": "本地部署",
+    "message": "本地体验",
     "description": "The label for category Locally in sidebar docs"
   },
   "sidebar.docs.category.Docker": {
-    "message": "Docker 部署",
+    "message": "Docker 体验",
     "description": "The label for category Docker in sidebar docs"
   },
   "sidebar.docs.category.Kubernetes": {
@@ -52,15 +52,15 @@
     "description": "The label for category Kubernetes in sidebar docs"
   },
   "sidebar.docs.category.Connectors": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connectors in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -68,11 +68,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -80,11 +80,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -92,15 +92,15 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Common Options": {
-    "message": "通用选项",
+    "message": "通用参数",
     "description": "The label for category Common Options in sidebar docs"
   },
   "sidebar.docs.category.Changelog": {
-    "message": "变更日志",
+    "message": "更新记录",
     "description": "The label for category Changelog in sidebar docs"
   },
   "sidebar.docs.category.Changelog.link.generated-index.title": {
-    "message": "连接器变更日志",
+    "message": "连接器更新记录",
     "description": "The generated-index page title for category Changelog in sidebar docs"
   },
   "sidebar.docs.category.Changelog.link.generated-index.description": {
@@ -108,11 +108,11 @@
     "description": "The generated-index page description for category Changelog in sidebar docs"
   },
   "sidebar.docs.category.Transforms": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Transforms.link.generated-index.title": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The generated-index page title for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Transforms.link.generated-index.description": {
@@ -120,15 +120,15 @@
     "description": "The generated-index page description for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Engines": {
-    "message": "引擎",
+    "message": "运行引擎",
     "description": "The label for category Engines in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine (Zeta)": {
-    "message": "SeaTunnel 引擎（Zeta）",
+    "message": "SeaTunnel 自研引擎（Zeta）",
     "description": "The label for category SeaTunnel Engine (Zeta) in sidebar docs"
   },
   "sidebar.docs.category.Deployment": {
-    "message": "部署",
+    "message": "部署方式",
     "description": "The label for category Deployment in sidebar docs"
   },
   "sidebar.docs.category.REST API": {
@@ -136,27 +136,27 @@
     "description": "The label for category REST API in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Tools": {
-    "message": "工具",
+    "message": "实用工具",
     "description": "The label for category Tools in sidebar docs"
   },
   "sidebar.docs.category.Developer": {
-    "message": "开发者",
+    "message": "开发者指南",
     "description": "The label for category Developer in sidebar docs"
   },
   "sidebar.docs.category.Tuning": {
-    "message": "调优",
+    "message": "性能调优",
     "description": "The label for category Tuning in sidebar docs"
   },
   "sidebar.docs.category.Ecosystem": {
-    "message": "生态系统",
+    "message": "实用工具",
     "description": "The label for category Ecosystem in sidebar docs"
   },
   "sidebar.docs.category.Compatibility": {
-    "message": "兼容性",
+    "message": "兼容性说明",
     "description": "The label for category Compatibility in sidebar docs"
   },
   "sidebar.docs.category.Connector Development": {
@@ -164,7 +164,7 @@
     "description": "The label for category Connector Development in sidebar docs"
   },
   "sidebar.docs.category.FAQ": {
-    "message": "常见问题解答",
+    "message": "常见问题",
     "description": "The label for category FAQ in sidebar docs"
   }
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,170 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Configuration": {
+    "message": "配置",
+    "description": "The label for category Configuration in sidebar docs"
+  },
+  "sidebar.docs.category.Architecture": {
+    "message": "架构",
+    "description": "The label for category Architecture in sidebar docs"
+  },
+  "sidebar.docs.category.API Design": {
+    "message": "API 设计",
+    "description": "The label for category API Design in sidebar docs"
+  },
+  "sidebar.docs.category.Engine": {
+    "message": "引擎",
+    "description": "The label for category Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Fault Tolerance": {
+    "message": "容错",
+    "description": "The label for category Fault Tolerance in sidebar docs"
+  },
+  "sidebar.docs.category.Features": {
+    "message": "特性",
+    "description": "The label for category Features in sidebar docs"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "快速开始",
+    "description": "The label for category Getting Started in sidebar docs"
+  },
+  "sidebar.docs.category.Locally": {
+    "message": "本地部署",
+    "description": "The label for category Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Docker": {
+    "message": "Docker 部署",
+    "description": "The label for category Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Kubernetes": {
+    "message": "Kubernetes 部署",
+    "description": "The label for category Kubernetes in sidebar docs"
+  },
+  "sidebar.docs.category.Connectors": {
+    "message": "连接器",
+    "description": "The label for category Connectors in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source connectors supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink connectors supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Common Options": {
+    "message": "通用选项",
+    "description": "The label for category Common Options in sidebar docs"
+  },
+  "sidebar.docs.category.Changelog": {
+    "message": "变更日志",
+    "description": "The label for category Changelog in sidebar docs"
+  },
+  "sidebar.docs.category.Changelog.link.generated-index.title": {
+    "message": "连接器变更日志",
+    "description": "The generated-index page title for category Changelog in sidebar docs"
+  },
+  "sidebar.docs.category.Changelog.link.generated-index.description": {
+    "message": "Changelog for all connectors supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Changelog in sidebar docs"
+  },
+  "sidebar.docs.category.Transforms": {
+    "message": "转换",
+    "description": "The label for category Transforms in sidebar docs"
+  },
+  "sidebar.docs.category.Transforms.link.generated-index.title": {
+    "message": "转换",
+    "description": "The generated-index page title for category Transforms in sidebar docs"
+  },
+  "sidebar.docs.category.Transforms.link.generated-index.description": {
+    "message": "List all transforms supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Transforms in sidebar docs"
+  },
+  "sidebar.docs.category.Engines": {
+    "message": "引擎",
+    "description": "The label for category Engines in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine (Zeta)": {
+    "message": "SeaTunnel 引擎（Zeta）",
+    "description": "The label for category SeaTunnel Engine (Zeta) in sidebar docs"
+  },
+  "sidebar.docs.category.Deployment": {
+    "message": "部署",
+    "description": "The label for category Deployment in sidebar docs"
+  },
+  "sidebar.docs.category.REST API": {
+    "message": "REST API",
+    "description": "The label for category REST API in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Tools": {
+    "message": "工具",
+    "description": "The label for category Tools in sidebar docs"
+  },
+  "sidebar.docs.category.Developer": {
+    "message": "开发者",
+    "description": "The label for category Developer in sidebar docs"
+  },
+  "sidebar.docs.category.Tuning": {
+    "message": "调优",
+    "description": "The label for category Tuning in sidebar docs"
+  },
+  "sidebar.docs.category.Ecosystem": {
+    "message": "生态系统",
+    "description": "The label for category Ecosystem in sidebar docs"
+  },
+  "sidebar.docs.category.Compatibility": {
+    "message": "兼容性",
+    "description": "The label for category Compatibility in sidebar docs"
+  },
+  "sidebar.docs.category.Connector Development": {
+    "message": "连接器开发",
+    "description": "The label for category Connector Development in sidebar docs"
+  },
+  "sidebar.docs.category.FAQ": {
+    "message": "常见问题解答",
+    "description": "The label for category FAQ in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.x.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.x.json
@@ -1,0 +1,46 @@
+{
+  "version.label": {
+    "message": "1.x",
+    "description": "The label for version 1.x"
+  },
+  "sidebar.docs.category.Configuration": {
+    "message": "配置",
+    "description": "The label for category Configuration in sidebar docs"
+  },
+  "sidebar.docs.category.Filter-Plugin": {
+    "message": "过滤插件",
+    "description": "The label for category Filter-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Filter-Plugin.link.generated-index.title": {
+    "message": "SeaTunnel 过滤插件",
+    "description": "The generated-index page title for category Filter-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Filter-Plugin.link.generated-index.description": {
+    "message": "List all filter supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Filter-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Input-Plugin": {
+    "message": "输入插件",
+    "description": "The label for category Input-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Input-Plugin.link.generated-index.title": {
+    "message": "SeaTunnel 输入插件",
+    "description": "The generated-index page title for category Input-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Input-Plugin.link.generated-index.description": {
+    "message": "List all input supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Input-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Output-Plugin": {
+    "message": "输出插件",
+    "description": "The label for category Output-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Output-Plugin.link.generated-index.title": {
+    "message": "SeaTunnel 输出插件",
+    "description": "The generated-index page title for category Output-Plugin in sidebar docs"
+  },
+  "sidebar.docs.category.Output-Plugin.link.generated-index.description": {
+    "message": "List all output supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Output-Plugin in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.x.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.x.json
@@ -4,7 +4,7 @@
     "description": "The label for version 1.x"
   },
   "sidebar.docs.category.Configuration": {
-    "message": "配置",
+    "message": "基础配置",
     "description": "The label for category Configuration in sidebar docs"
   },
   "sidebar.docs.category.Filter-Plugin": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.0.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.0.json
@@ -1,0 +1,38 @@
+{
+  "version.label": {
+    "message": "2.1.0",
+    "description": "The label for version 2.1.0"
+  },
+  "sidebar.tutorialSidebar.category.developement": {
+    "message": "开发",
+    "description": "The label for category developement in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.flink": {
+    "message": "Flink",
+    "description": "The label for category flink in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.commands": {
+    "message": "命令",
+    "description": "The label for category commands in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.configuration": {
+    "message": "配置",
+    "description": "The label for category configuration in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.sink-plugins": {
+    "message": "Sink 插件",
+    "description": "The label for category sink-plugins in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.source-plugins": {
+    "message": "Source 插件",
+    "description": "The label for category source-plugins in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.transform-plugins": {
+    "message": "Transform 插件",
+    "description": "The label for category transform-plugins in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.spark": {
+    "message": "Spark",
+    "description": "The label for category spark in sidebar tutorialSidebar"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.1.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.1.json
@@ -4,11 +4,11 @@
     "description": "The label for version 2.1.1"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Quick Start": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start.link.generated-index.title": {
@@ -20,15 +20,15 @@
     "description": "The generated-index page description for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Connector": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connector in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -36,11 +36,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -48,11 +48,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.1.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.1.json
@@ -1,0 +1,62 @@
+{
+  "version.label": {
+    "message": "2.1.1",
+    "description": "The label for version 2.1.1"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start": {
+    "message": "快速开始",
+    "description": "The label for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.title": {
+    "message": "SeaTunnel 快速开始",
+    "description": "The generated-index page title for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Connector": {
+    "message": "连接器",
+    "description": "The label for category Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform": {
+    "message": "转换",
+    "description": "The label for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.2.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.2.json
@@ -1,0 +1,66 @@
+{
+  "version.label": {
+    "message": "2.1.2",
+    "description": "The label for version 2.1.2"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start": {
+    "message": "快速开始",
+    "description": "The label for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.title": {
+    "message": "SeaTunnel 快速开始",
+    "description": "The generated-index page title for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector": {
+    "message": "连接器",
+    "description": "The label for category Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform": {
+    "message": "转换",
+    "description": "The label for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.2.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.2.json
@@ -4,11 +4,11 @@
     "description": "The label for version 2.1.2"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Quick Start": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start.link.generated-index.title": {
@@ -20,19 +20,19 @@
     "description": "The generated-index page description for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connector in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.3.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.3.json
@@ -1,0 +1,86 @@
+{
+  "version.label": {
+    "message": "2.1.3",
+    "description": "The label for version 2.1.3"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start": {
+    "message": "快速开始",
+    "description": "The label for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.title": {
+    "message": "SeaTunnel 快速开始",
+    "description": "The generated-index page title for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector": {
+    "message": "连接器",
+    "description": "The label for category Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql": {
+    "message": "Flink SQL",
+    "description": "The label for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql.link.generated-index.title": {
+    "message": "SeaTunnel Flink SQL",
+    "description": "The generated-index page title for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql.link.generated-index.description": {
+    "message": "List all flink-sql supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.Transform": {
+    "message": "转换",
+    "description": "The label for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.title": {
+    "message": "SeaTunnel 转换",
+    "description": "The generated-index page title for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.description": {
+    "message": "List all transform supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.3.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1.3.json
@@ -4,11 +4,11 @@
     "description": "The label for version 2.1.3"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Quick Start": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start.link.generated-index.title": {
@@ -20,19 +20,19 @@
     "description": "The generated-index page description for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connector in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category flink-sql in sidebar docs"
   },
   "sidebar.docs.category.Transform": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Transform.link.generated-index.title": {
@@ -76,7 +76,7 @@
     "description": "The generated-index page description for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.2.0-beta.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.2.0-beta.json
@@ -1,0 +1,102 @@
+{
+  "version.label": {
+    "message": "2.2.0-beta",
+    "description": "The label for version 2.2.0-beta"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start": {
+    "message": "快速开始",
+    "description": "The label for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.title": {
+    "message": "SeaTunnel 快速开始",
+    "description": "The generated-index page title for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start - V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 快速开始",
+    "description": "The generated-index page title for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start - V2.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector": {
+    "message": "连接器",
+    "description": "The label for category Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql": {
+    "message": "Flink SQL",
+    "description": "The label for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql.link.generated-index.title": {
+    "message": "SeaTunnel Flink SQL",
+    "description": "The generated-index page title for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql.link.generated-index.description": {
+    "message": "List all flink-sql supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform": {
+    "message": "转换",
+    "description": "The label for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.title": {
+    "message": "SeaTunnel 转换",
+    "description": "The generated-index page title for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.description": {
+    "message": "List all transform supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.2.0-beta.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.2.0-beta.json
@@ -4,11 +4,11 @@
     "description": "The label for version 2.2.0-beta"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Quick Start": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start.link.generated-index.title": {
@@ -20,7 +20,7 @@
     "description": "The generated-index page description for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Quick Start - V2.link.generated-index.title": {
@@ -32,19 +32,19 @@
     "description": "The generated-index page description for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connector in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -76,11 +76,11 @@
     "description": "The generated-index page description for category flink-sql in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Transform.link.generated-index.title": {
@@ -92,7 +92,7 @@
     "description": "The generated-index page description for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0-beta.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0-beta.json
@@ -4,11 +4,11 @@
     "description": "The label for version 2.3.0-beta"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Quick Start": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start.link.generated-index.title": {
@@ -20,7 +20,7 @@
     "description": "The generated-index page description for category Quick Start in sidebar docs"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Quick Start - V2.link.generated-index.title": {
@@ -32,19 +32,19 @@
     "description": "The generated-index page description for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connector in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -76,11 +76,11 @@
     "description": "The generated-index page description for category flink-sql in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Transform.link.generated-index.title": {
@@ -92,7 +92,7 @@
     "description": "The generated-index page description for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0-beta.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0-beta.json
@@ -1,0 +1,102 @@
+{
+  "version.label": {
+    "message": "2.3.0-beta",
+    "description": "The label for version 2.3.0-beta"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start": {
+    "message": "快速开始",
+    "description": "The label for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.title": {
+    "message": "SeaTunnel 快速开始",
+    "description": "The generated-index page title for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start - V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 快速开始",
+    "description": "The generated-index page title for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start - V2.link.generated-index.description": {
+    "message": "In this section, you could learn how to get up and running Apache SeaTunnel in both locally or in Docker environment.",
+    "description": "The generated-index page description for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector": {
+    "message": "连接器",
+    "description": "The label for category Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql": {
+    "message": "Flink SQL",
+    "description": "The label for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql.link.generated-index.title": {
+    "message": "SeaTunnel Flink SQL",
+    "description": "The generated-index page title for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.flink-sql.link.generated-index.description": {
+    "message": "List all flink-sql supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category flink-sql in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform": {
+    "message": "转换",
+    "description": "The label for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.title": {
+    "message": "SeaTunnel 转换",
+    "description": "The generated-index page title for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.description": {
+    "message": "List all transform supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.0",
+    "description": "The label for version 2.3.0"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform": {
+    "message": "转换",
+    "description": "The label for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.title": {
+    "message": "SeaTunnel 转换",
+    "description": "The generated-index page title for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Transform.link.generated-index.description": {
+    "message": "List all transform supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.0.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.0"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Transform.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.1.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.1.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.1"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.1.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.1.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.1",
+    "description": "The label for version 2.3.1"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.10.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.10.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.10"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -76,7 +76,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -84,11 +84,11 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Deployment": {
-    "message": "部署",
+    "message": "部署方式",
     "description": "The label for category Deployment in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.10.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.10.json
@@ -1,0 +1,98 @@
+{
+  "version.label": {
+    "message": "2.3.10",
+    "description": "The label for version 2.3.10"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats (not all) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Deployment": {
+    "message": "部署",
+    "description": "The label for category Deployment in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.11.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.11.json
@@ -1,0 +1,102 @@
+{
+  "version.label": {
+    "message": "2.3.11",
+    "description": "The label for version 2.3.11"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats (not all) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Deployment": {
+    "message": "部署",
+    "description": "The label for category Deployment in sidebar docs"
+  },
+  "sidebar.docs.category.RESTFul API": {
+    "message": "RESTFul API",
+    "description": "The label for category RESTFul API in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.11.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.11.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.11"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -76,7 +76,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -84,15 +84,15 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Deployment": {
-    "message": "部署",
+    "message": "部署方式",
     "description": "The label for category Deployment in sidebar docs"
   },
   "sidebar.docs.category.RESTFul API": {
-    "message": "RESTFul API",
+    "message": "REST API",
     "description": "The label for category RESTFul API in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.12.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.12.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.12"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -76,7 +76,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -84,15 +84,15 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Deployment": {
-    "message": "部署",
+    "message": "部署方式",
     "description": "The label for category Deployment in sidebar docs"
   },
   "sidebar.docs.category.RESTFul API": {
-    "message": "RESTFul API",
+    "message": "REST API",
     "description": "The label for category RESTFul API in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.12.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.12.json
@@ -1,0 +1,102 @@
+{
+  "version.label": {
+    "message": "2.3.12",
+    "description": "The label for version 2.3.12"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats (not all) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Deployment": {
+    "message": "部署",
+    "description": "The label for category Deployment in sidebar docs"
+  },
+  "sidebar.docs.category.RESTFul API": {
+    "message": "RESTFul API",
+    "description": "The label for category RESTFul API in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13.json
@@ -116,7 +116,7 @@
     "description": "The generated-index page title for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Transforms.link.generated-index.description": {
-    "message": "List all transforms supported by Apache SeaTunnel.",
+    "message": "查看 Apache SeaTunnel 支持的全部数据转换能力，并按场景选择合适的转换插件。",
     "description": "The generated-index page description for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Engines": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13.json
@@ -1,0 +1,150 @@
+{
+  "version.label": {
+    "message": "2.3.13",
+    "description": "The label for version 2.3.13"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "简介",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Configuration": {
+    "message": "配置",
+    "description": "The label for category Configuration in sidebar docs"
+  },
+  "sidebar.docs.category.Architecture": {
+    "message": "架构",
+    "description": "The label for category Architecture in sidebar docs"
+  },
+  "sidebar.docs.category.API Design": {
+    "message": "API 设计",
+    "description": "The label for category API Design in sidebar docs"
+  },
+  "sidebar.docs.category.Engine": {
+    "message": "引擎",
+    "description": "The label for category Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Fault Tolerance": {
+    "message": "容错",
+    "description": "The label for category Fault Tolerance in sidebar docs"
+  },
+  "sidebar.docs.category.Features": {
+    "message": "特性",
+    "description": "The label for category Features in sidebar docs"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "快速开始",
+    "description": "The label for category Getting Started in sidebar docs"
+  },
+  "sidebar.docs.category.Locally": {
+    "message": "本地部署",
+    "description": "The label for category Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Docker": {
+    "message": "Docker 部署",
+    "description": "The label for category Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Kubernetes": {
+    "message": "Kubernetes 部署",
+    "description": "The label for category Kubernetes in sidebar docs"
+  },
+  "sidebar.docs.category.Connectors": {
+    "message": "连接器",
+    "description": "The label for category Connectors in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source connectors supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink connectors supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Common Options": {
+    "message": "通用选项",
+    "description": "The label for category Common Options in sidebar docs"
+  },
+  "sidebar.docs.category.Changelog": {
+    "message": "变更日志",
+    "description": "The label for category Changelog in sidebar docs"
+  },
+  "sidebar.docs.category.Changelog.link.generated-index.title": {
+    "message": "连接器变更日志",
+    "description": "The generated-index page title for category Changelog in sidebar docs"
+  },
+  "sidebar.docs.category.Changelog.link.generated-index.description": {
+    "message": "Changelog for all connectors supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Changelog in sidebar docs"
+  },
+  "sidebar.docs.category.Transforms": {
+    "message": "转换",
+    "description": "The label for category Transforms in sidebar docs"
+  },
+  "sidebar.docs.category.Transforms.link.generated-index.title": {
+    "message": "转换",
+    "description": "The generated-index page title for category Transforms in sidebar docs"
+  },
+  "sidebar.docs.category.Transforms.link.generated-index.description": {
+    "message": "List all transforms supported by Apache SeaTunnel.",
+    "description": "The generated-index page description for category Transforms in sidebar docs"
+  },
+  "sidebar.docs.category.Engines": {
+    "message": "引擎",
+    "description": "The label for category Engines in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine (Zeta)": {
+    "message": "SeaTunnel 引擎（Zeta）",
+    "description": "The label for category SeaTunnel Engine (Zeta) in sidebar docs"
+  },
+  "sidebar.docs.category.Deployment": {
+    "message": "部署",
+    "description": "The label for category Deployment in sidebar docs"
+  },
+  "sidebar.docs.category.REST API": {
+    "message": "REST API",
+    "description": "The label for category REST API in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.Ecosystem": {
+    "message": "生态系统",
+    "description": "The label for category Ecosystem in sidebar docs"
+  },
+  "sidebar.docs.category.Developer": {
+    "message": "开发者",
+    "description": "The label for category Developer in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13.json
@@ -4,19 +4,19 @@
     "description": "The label for version 2.3.13"
   },
   "sidebar.docs.category.Introduction": {
-    "message": "简介",
+    "message": "认识 SeaTunnel",
     "description": "The label for category Introduction in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Configuration": {
-    "message": "配置",
+    "message": "基础配置",
     "description": "The label for category Configuration in sidebar docs"
   },
   "sidebar.docs.category.Architecture": {
-    "message": "架构",
+    "message": "架构与原理",
     "description": "The label for category Architecture in sidebar docs"
   },
   "sidebar.docs.category.API Design": {
@@ -24,27 +24,27 @@
     "description": "The label for category API Design in sidebar docs"
   },
   "sidebar.docs.category.Engine": {
-    "message": "引擎",
+    "message": "引擎原理",
     "description": "The label for category Engine in sidebar docs"
   },
   "sidebar.docs.category.Fault Tolerance": {
-    "message": "容错",
+    "message": "容错机制",
     "description": "The label for category Fault Tolerance in sidebar docs"
   },
   "sidebar.docs.category.Features": {
-    "message": "特性",
+    "message": "关键特性",
     "description": "The label for category Features in sidebar docs"
   },
   "sidebar.docs.category.Getting Started": {
-    "message": "快速开始",
+    "message": "快速上手",
     "description": "The label for category Getting Started in sidebar docs"
   },
   "sidebar.docs.category.Locally": {
-    "message": "本地部署",
+    "message": "本地体验",
     "description": "The label for category Locally in sidebar docs"
   },
   "sidebar.docs.category.Docker": {
-    "message": "Docker 部署",
+    "message": "Docker 体验",
     "description": "The label for category Docker in sidebar docs"
   },
   "sidebar.docs.category.Kubernetes": {
@@ -52,15 +52,15 @@
     "description": "The label for category Kubernetes in sidebar docs"
   },
   "sidebar.docs.category.Connectors": {
-    "message": "连接器",
+    "message": "数据连接器",
     "description": "The label for category Connectors in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -68,11 +68,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -80,11 +80,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -92,15 +92,15 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Common Options": {
-    "message": "通用选项",
+    "message": "通用参数",
     "description": "The label for category Common Options in sidebar docs"
   },
   "sidebar.docs.category.Changelog": {
-    "message": "变更日志",
+    "message": "更新记录",
     "description": "The label for category Changelog in sidebar docs"
   },
   "sidebar.docs.category.Changelog.link.generated-index.title": {
-    "message": "连接器变更日志",
+    "message": "连接器更新记录",
     "description": "The generated-index page title for category Changelog in sidebar docs"
   },
   "sidebar.docs.category.Changelog.link.generated-index.description": {
@@ -108,11 +108,11 @@
     "description": "The generated-index page description for category Changelog in sidebar docs"
   },
   "sidebar.docs.category.Transforms": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The label for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Transforms.link.generated-index.title": {
-    "message": "转换",
+    "message": "数据转换",
     "description": "The generated-index page title for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Transforms.link.generated-index.description": {
@@ -120,15 +120,15 @@
     "description": "The generated-index page description for category Transforms in sidebar docs"
   },
   "sidebar.docs.category.Engines": {
-    "message": "引擎",
+    "message": "运行引擎",
     "description": "The label for category Engines in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine (Zeta)": {
-    "message": "SeaTunnel 引擎（Zeta）",
+    "message": "SeaTunnel 自研引擎（Zeta）",
     "description": "The label for category SeaTunnel Engine (Zeta) in sidebar docs"
   },
   "sidebar.docs.category.Deployment": {
-    "message": "部署",
+    "message": "部署方式",
     "description": "The label for category Deployment in sidebar docs"
   },
   "sidebar.docs.category.REST API": {
@@ -136,15 +136,15 @@
     "description": "The label for category REST API in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.Ecosystem": {
-    "message": "生态系统",
+    "message": "实用工具",
     "description": "The label for category Ecosystem in sidebar docs"
   },
   "sidebar.docs.category.Developer": {
-    "message": "开发者",
+    "message": "开发者指南",
     "description": "The label for category Developer in sidebar docs"
   }
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.2.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.2.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.2",
+    "description": "The label for version 2.3.2"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.2.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.2.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.2"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.3.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.3.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.3",
+    "description": "The label for version 2.3.3"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.3.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.3.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.3"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.4.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.4.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.4",
+    "description": "The label for version 2.3.4"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.4.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.4.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.4"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.5.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.5.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.5"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.5.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.5.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.5",
+    "description": "The label for version 2.3.5"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.6.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.6.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.6"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.6.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.6.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.6",
+    "description": "The label for version 2.3.6"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.7.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.7.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "2.3.7",
+    "description": "The label for version 2.3.7"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concept": {
+    "message": "概念",
+    "description": "The label for category Concept in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.7.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.7.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.7"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concept": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concept in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,7 +52,7 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -72,7 +72,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.8.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.8.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.8"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -76,7 +76,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -84,7 +84,7 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.8.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.8.json
@@ -1,0 +1,94 @@
+{
+  "version.label": {
+    "message": "2.3.8",
+    "description": "The label for version 2.3.8"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats (not all) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.9.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.9.json
@@ -4,35 +4,35 @@
     "description": "The label for version 2.3.9"
   },
   "sidebar.docs.category.Quick Start - V2": {
-    "message": "快速开始 - V2",
+    "message": "V2 快速上手",
     "description": "The label for category Quick Start - V2 in sidebar docs"
   },
   "sidebar.docs.category.Start With Locally": {
-    "message": "本地开始",
+    "message": "本地体验",
     "description": "The label for category Start With Locally in sidebar docs"
   },
   "sidebar.docs.category.Start With Docker": {
-    "message": "使用 Docker 开始",
+    "message": "Docker 体验",
     "description": "The label for category Start With Docker in sidebar docs"
   },
   "sidebar.docs.category.Start With K8s": {
-    "message": "使用 K8s 开始",
+    "message": "K8s 部署",
     "description": "The label for category Start With K8s in sidebar docs"
   },
   "sidebar.docs.category.Concepts": {
-    "message": "概念",
+    "message": "核心概念",
     "description": "The label for category Concepts in sidebar docs"
   },
   "sidebar.docs.category.Connector-V2": {
-    "message": "连接器 V2",
+    "message": "数据连接器 V2",
     "description": "The label for category Connector-V2 in sidebar docs"
   },
   "sidebar.docs.category.Source": {
-    "message": "源端",
+    "message": "数据来源",
     "description": "The label for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.title": {
-    "message": "SeaTunnel V2 源连接器",
+    "message": "数据来源连接器",
     "description": "The generated-index page title for category Source in sidebar docs"
   },
   "sidebar.docs.category.Source.link.generated-index.description": {
@@ -40,11 +40,11 @@
     "description": "The generated-index page description for category Source in sidebar docs"
   },
   "sidebar.docs.category.Sink": {
-    "message": "目标端",
+    "message": "数据写入",
     "description": "The label for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.title": {
-    "message": "SeaTunnel V2 目标连接器",
+    "message": "数据写入连接器",
     "description": "The generated-index page title for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Sink.link.generated-index.description": {
@@ -52,11 +52,11 @@
     "description": "The generated-index page description for category Sink in sidebar docs"
   },
   "sidebar.docs.category.Formats": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The label for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.title": {
-    "message": "格式",
+    "message": "数据格式",
     "description": "The generated-index page title for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Formats.link.generated-index.description": {
@@ -64,7 +64,7 @@
     "description": "The generated-index page description for category Formats in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2": {
-    "message": "转换 V2",
+    "message": "数据转换 V2",
     "description": "The label for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Transform-V2.link.generated-index.title": {
@@ -76,7 +76,7 @@
     "description": "The generated-index page description for category Transform-V2 in sidebar docs"
   },
   "sidebar.docs.category.Command": {
-    "message": "命令",
+    "message": "命令行",
     "description": "The label for category Command in sidebar docs"
   },
   "sidebar.docs.category.SeaTunnel Engine": {
@@ -84,11 +84,11 @@
     "description": "The label for category SeaTunnel Engine in sidebar docs"
   },
   "sidebar.docs.category.Deployment": {
-    "message": "部署",
+    "message": "部署方式",
     "description": "The label for category Deployment in sidebar docs"
   },
   "sidebar.docs.category.Other Engine": {
-    "message": "其他引擎",
+    "message": "其他运行引擎",
     "description": "The label for category Other Engine in sidebar docs"
   },
   "sidebar.docs.category.Contribution": {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.9.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.9.json
@@ -1,0 +1,98 @@
+{
+  "version.label": {
+    "message": "2.3.9",
+    "description": "The label for version 2.3.9"
+  },
+  "sidebar.docs.category.Quick Start - V2": {
+    "message": "快速开始 - V2",
+    "description": "The label for category Quick Start - V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Locally": {
+    "message": "本地开始",
+    "description": "The label for category Start With Locally in sidebar docs"
+  },
+  "sidebar.docs.category.Start With Docker": {
+    "message": "使用 Docker 开始",
+    "description": "The label for category Start With Docker in sidebar docs"
+  },
+  "sidebar.docs.category.Start With K8s": {
+    "message": "使用 K8s 开始",
+    "description": "The label for category Start With K8s in sidebar docs"
+  },
+  "sidebar.docs.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Connector-V2": {
+    "message": "连接器 V2",
+    "description": "The label for category Connector-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Source": {
+    "message": "源端",
+    "description": "The label for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.title": {
+    "message": "SeaTunnel V2 源连接器",
+    "description": "The generated-index page title for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Source.link.generated-index.description": {
+    "message": "List all source(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Source in sidebar docs"
+  },
+  "sidebar.docs.category.Sink": {
+    "message": "目标端",
+    "description": "The label for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.title": {
+    "message": "SeaTunnel V2 目标连接器",
+    "description": "The generated-index page title for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Sink.link.generated-index.description": {
+    "message": "List all sink(v2) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Sink in sidebar docs"
+  },
+  "sidebar.docs.category.Formats": {
+    "message": "格式",
+    "description": "The label for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.title": {
+    "message": "格式",
+    "description": "The generated-index page title for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Formats.link.generated-index.description": {
+    "message": "List some special formats (not all) supported by Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Formats in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2": {
+    "message": "转换 V2",
+    "description": "The label for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.title": {
+    "message": "SeaTunnel V2 转换",
+    "description": "The generated-index page title for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Transform-V2.link.generated-index.description": {
+    "message": "List all transform v2 supported Apache SeaTunnel for now.",
+    "description": "The generated-index page description for category Transform-V2 in sidebar docs"
+  },
+  "sidebar.docs.category.Command": {
+    "message": "命令",
+    "description": "The label for category Command in sidebar docs"
+  },
+  "sidebar.docs.category.SeaTunnel Engine": {
+    "message": "SeaTunnel 引擎",
+    "description": "The label for category SeaTunnel Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Deployment": {
+    "message": "部署",
+    "description": "The label for category Deployment in sidebar docs"
+  },
+  "sidebar.docs.category.Other Engine": {
+    "message": "其他引擎",
+    "description": "The label for category Other Engine in sidebar docs"
+  },
+  "sidebar.docs.category.Contribution": {
+    "message": "贡献指南",
+    "description": "The label for category Contribution in sidebar docs"
+  }
+}


### PR DESCRIPTION
## Summary
- add zh-CN docs sidebar translation files for current docs and all tracked versioned docs
- localize level 1, level 2, and level 3 sidebar category labels into Chinese
- localize generated index titles for connector, transform, and legacy plugin category pages

## Validation
- `node` JSON parse for `i18n/zh-CN/docusaurus-plugin-content-docs/*.json`
- attempted `docusaurus start --locale zh-CN --host 127.0.0.1 --port 3005` in the PR worktree
- attempted `docusaurus start --locale zh-CN --host 127.0.0.1 --port 3006` in `/Users/stone/work/myworkspace/seatunnel-website`
- reused artifacts: `/Users/stone/work/myworkspace/seatunnel_third/seatunnel-website/node_modules`, plus temporary ignored `docs/` and `sidebars.js` for local preview only
- not fully revalidated in this run: browser-level sidebar rendering. The first dev-server compile stayed busy on the full historical docs set and repeated legacy SVG warnings, so the local preview never returned HTML within the available window.

## Risk
- low code risk because the change is limited to zh-CN translation JSON files
- remaining risk is limited to untranslated or newly introduced sidebar keys that are outside the currently tracked current/versioned sidebar sources