### PR TITLE
[Docs] Polish homepage narrative and visual hierarchy

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -243,7 +243,7 @@ html[data-theme='dark'] .dropdown__menu .dropdown__link {
 
 .footer {
   background: var(--st-shell-footer-bg);
-  border-top: 1px solid var(--st-shell-border);
+  border-top: none;
 }
 
 .footer,

--- a/src/pages/home/index.jsx
+++ b/src/pages/home/index.jsx
@@ -43,6 +43,8 @@ const HERO_SINKS = [
     {name: 'Apache Paimon', colorClass: 'pink'},
 ];
 
+const ARCHITECTURE_ROW_KEYS = ['top', 'mid', 'bot'];
+
 // Keep the marquee aligned with connectors and integrations that already have
 // public support pages in the current SeaTunnel documentation set.
 const CONNECTOR_MARQUEE_ITEMS = [
@@ -115,6 +117,8 @@ const CONNECTOR_MARQUEE_ITEMS = [
     'Web3j',
 ];
 
+const stripArchitectureStageIndex = (value) => value.replace(/^\d+\s+/, '');
+
 const HOME_COPY = {
     'en': {
         badge: `v${versions[0]} live / Apache Top-Level Project`,
@@ -129,7 +133,7 @@ const HOME_COPY = {
             titleLead: 'High-performance',
             titleAccent: 'data integration',
             titleTail: 'for every workload.',
-            subtitle: 'Build one pipeline definition and run it on Zeta, Flink, or Spark. SeaTunnel powers batch, streaming, CDC, multimodal, and AI data movement across production systems.',
+            subtitle: 'A production-grade integration layer for distributed data systems, with fault tolerance, schema evolution, and multi-engine execution across batch, streaming, CDC, multimodal, and AI workloads.',
             primaryButton: 'Quick Start',
             secondaryButton: 'Read the Docs',
             helperButton: 'View Connectors',
@@ -152,13 +156,13 @@ const HOME_COPY = {
             {value: '2.3k+', label: 'GitHub Forks'},
         ],
         architecture: {
-            eyebrow: 'Architecture',
+            eyebrow: 'Architecture Pattern',
             titleLead: 'Not ETL.',
             titleAccent: 'EtLT.',
             lead: 'SeaTunnel handles extract, lightweight transform, and load. Your warehouse or lakehouse can keep the heavy downstream transformation while SeaTunnel moves reliable, structured data between systems.',
             headers: {
                 sources: '01 Upstream Sources',
-                engine: '02 EtLT Engine',
+                engine: '02 EtLT PATTERN',
                 targets: '03 Downstream Targets',
             },
             rows: [
@@ -179,7 +183,7 @@ const HOME_COPY = {
                 {
                     source: {
                         title: 'Streaming',
-                        tag: 'Pub/Sub',
+                        tag: 'Pub / Sub',
                         dotClass: 'blue',
                         chips: ['Apache Kafka', 'Apache Pulsar', 'RocketMQ', 'RabbitMQ'],
                     },
@@ -192,22 +196,28 @@ const HOME_COPY = {
                 },
                 {
                     source: {
-                        title: 'Data Lake',
+                        title: 'Files & Lake',
                         tag: 'Object Storage',
-                        dotClass: 'orange',
+                        dotClass: 'teal',
                         chips: ['Amazon S3', 'Alibaba OSS', 'HDFS', 'LocalFile'],
                     },
                     target: {
-                        title: 'AI & Analytics',
-                        tag: 'Vector / LLM',
-                        dotClass: 'purple',
-                        chips: ['Milvus', 'Qdrant', 'Elasticsearch', 'Typesense'],
+                        title: 'Search & Vectors',
+                        tag: 'Retrieval',
+                        dotClass: 'blue',
+                        chips: ['Elasticsearch', 'Typesense', 'Milvus', 'Qdrant'],
                     },
                 },
             ],
-            engineBadges: [
-                'Zeta Engine / Apache Flink / Apache Spark',
-                'CDC / Exactly-Once / Schema Evolution',
+            enginePillars: [
+                {label: 'Engines', value: 'Zeta / Flink / Spark'},
+                {label: 'Modes', value: 'Batch / Streaming / CDC'},
+                {label: 'Guarantees', value: 'Exactly-once / Schema evolution / Multi-engine scale'},
+            ],
+            engineFoot: [
+                '200+ Connectors',
+                'Structured Movement',
+                'Production Ready',
             ],
         },
         features: {
@@ -225,9 +235,10 @@ const HOME_COPY = {
                 {
                     number: '02',
                     title: 'Real-Time CDC',
-                    description: 'Capture INSERT, UPDATE, and DELETE events from MySQL, Oracle, PostgreSQL, SQL Server, MongoDB, and more with low latency.',
+                    description: 'Low-latency change capture across major databases, with seamless batch-to-stream handoff and no lock-based cutover.',
                     icon: 'lightning',
                     accent: 'blue',
+                    highlights: ['Low latency', 'Batch to stream', 'No lock cutover'],
                 },
                 {
                     number: '03',
@@ -235,13 +246,16 @@ const HOME_COPY = {
                     description: 'Checkpoint-backed fault tolerance keeps records consistent across failures, retries, and restarts.',
                     icon: 'shield',
                     accent: 'teal',
+                    highlights: ['Checkpoint backed', 'Failure safe', 'Restart consistent'],
                 },
                 {
                     number: '04',
                     title: 'Multi-Engine Support',
-                    description: 'Write one pipeline definition and run it on Zeta, Flink, or Spark without rewriting connector logic.',
+                    description: 'Use the same pipeline definition on Zeta, Flink, or Spark without rewriting connector logic or delivery paths.',
                     icon: 'layers',
                     accent: 'amber',
+                    highlights: ['One definition', 'Zeta / Flink / Spark', 'No connector rewrites'],
+                    layout: 'wide',
                 },
             ],
         },
@@ -298,30 +312,6 @@ const HOME_COPY = {
             ],
             more: 'Also: MongoDB / Redis / Elasticsearch / Neo4j / Cassandra / HBase / Druid / HugeGraph / IoTDB / InfluxDB / DynamoDB / Milvus / Qdrant ...',
         },
-        flow: {
-            eyebrow: 'How it works',
-            titleLead: 'Extract. transform. Load. Transform.',
-            titleAccent: 'Elegantly simple.',
-            lead: 'One config file defines the full EtLT pipeline, from ingestion through lightweight transformation and delivery.',
-            steps: [
-                {
-                    label: '01 Extract',
-                    title: 'Read from anywhere',
-                    tags: ['MySQL-CDC', 'Kafka', 'PostgreSQL', 'MongoDB', 'Oracle', 'S3', 'Hive', '+193 more'],
-                },
-                {
-                    label: '02 Lightweight transform',
-                    title: 'Shape and enrich in-flight',
-                    tags: ['SQL Transform', 'FieldMapper', 'Copy', 'Replace', 'FieldEncrypt', 'Split', 'FilterRowKind', 'Jsonpath'],
-                    highlight: true,
-                },
-                {
-                    label: '03 Load',
-                    title: 'Deliver anywhere',
-                    tags: ['ClickHouse', 'Iceberg', 'Doris', 'StarRocks', 'Paimon', 'Kafka', 'Redis', '+193 more'],
-                },
-            ],
-        },
         code: {
             eyebrow: 'Simple by design',
             titleLead: 'A config file.',
@@ -332,9 +322,9 @@ const HOME_COPY = {
             fileName: 'mysql-cdc-to-clickhouse.conf',
         },
         cta: {
-            titleLead: 'Start moving your data',
-            titleAccent: 'without limits.',
-            lead: 'Open source. Apache licensed. Free forever. Built for production teams that need a reliable integration layer instead of another fragile demo.',
+            titleLead: 'One pipeline definition.',
+            titleAccent: 'Run it on Zeta, Flink, or Spark.',
+            lead: 'SeaTunnel unifies CDC, schema evolution, multimodal movement, and production-grade reliability into one Apache-licensed integration layer.',
             primaryButton: 'Quick Start',
             secondaryButton: 'GitHub',
             tertiaryButton: 'Slack Access',
@@ -390,7 +380,7 @@ const HOME_COPY = {
             titleLead: '超高性能',
             titleAccent: '数据集成',
             titleTail: '工具',
-            subtitle: '支持多模态数据集成，一次定义 pipeline，可运行在 Zeta、Flink 和 Spark 上，覆盖批处理、流处理、CDC 与实时同步场景。',
+            subtitle: '面向分布式生产系统的数据集成底座，具备容错、模式演进与多引擎执行能力，覆盖批处理、流处理、CDC、多模态与 AI 数据场景。',
             primaryButton: '快速开始',
             secondaryButton: '阅读文档',
             helperButton: '查看连接器',
@@ -413,13 +403,13 @@ const HOME_COPY = {
             {value: '2.3k+', label: 'GitHub Forks'},
         ],
         architecture: {
-            eyebrow: '架构',
+            eyebrow: '架构模式',
             titleLead: '不是 ETL',
             titleAccent: '而是 EtLT',
             lead: 'SeaTunnel 负责抽取、轻量转换与装载，把重量级的下游转换保留给仓库或湖仓，让数据链路更清晰也更稳定。',
             headers: {
                 sources: '01 上游数据源',
-                engine: '02 EtLT 引擎',
+                engine: '02 EtLT 模式',
                 targets: '03 下游目标',
             },
             rows: [
@@ -440,7 +430,7 @@ const HOME_COPY = {
                 {
                     source: {
                         title: '消息流',
-                        tag: 'Pub/Sub',
+                        tag: '发布 / 订阅',
                         dotClass: 'blue',
                         chips: ['Apache Kafka', 'Apache Pulsar', 'RocketMQ', 'RabbitMQ'],
                     },
@@ -453,22 +443,28 @@ const HOME_COPY = {
                 },
                 {
                     source: {
-                        title: '数据湖',
-                        tag: 'Object Storage',
-                        dotClass: 'orange',
+                        title: '文件与数据湖',
+                        tag: '对象存储',
+                        dotClass: 'teal',
                         chips: ['Amazon S3', 'Alibaba OSS', 'HDFS', 'LocalFile'],
                     },
                     target: {
-                        title: 'AI 与分析',
-                        tag: 'Vector / LLM',
-                        dotClass: 'purple',
-                        chips: ['Milvus', 'Qdrant', 'Elasticsearch', 'Typesense'],
+                        title: '搜索与向量',
+                        tag: '检索',
+                        dotClass: 'blue',
+                        chips: ['Elasticsearch', 'Typesense', 'Milvus', 'Qdrant'],
                     },
                 },
             ],
-            engineBadges: [
-                'Zeta Engine / Apache Flink / Apache Spark',
-                'CDC / Exactly-Once / Schema Evolution',
+            enginePillars: [
+                {label: '引擎', value: 'Zeta / Flink / Spark'},
+                {label: '模式', value: '批处理 / 流处理 / CDC'},
+                {label: '保障', value: 'Exactly-once / 模式演进 / 多引擎扩展'},
+            ],
+            engineFoot: [
+                '200+ Connectors',
+                'Structured Movement',
+                'Production Ready',
             ],
         },
         features: {
@@ -486,9 +482,10 @@ const HOME_COPY = {
                 {
                     number: '02',
                     title: '实时 CDC',
-                    description: '支持 MySQL、Oracle、PostgreSQL、SQL Server、MongoDB 等多种数据库的实时变更捕获。',
+                    description: '面向主流数据库的低延迟变更捕获，同时支持从批到流无缝衔接，并避免锁式切换。',
                     icon: 'lightning',
                     accent: 'blue',
+                    highlights: ['低延迟', '批流衔接', '无锁切换'],
                 },
                 {
                     number: '03',
@@ -496,13 +493,16 @@ const HOME_COPY = {
                     description: '基于 checkpoint 的容错保证任务在失败、重试与重启场景下仍保持数据一致性。',
                     icon: 'shield',
                     accent: 'teal',
+                    highlights: ['Checkpoint 保障', '失败可恢复', '重启仍一致'],
                 },
                 {
                     number: '04',
                     title: '多引擎支持',
-                    description: '同一份 pipeline 定义可运行在 Zeta、Flink 或 Spark 上，无需重写连接器逻辑。',
+                    description: '同一份 pipeline 定义可运行在 Zeta、Flink 或 Spark 上，无需重写连接器逻辑与交付链路。',
                     icon: 'layers',
                     accent: 'amber',
+                    highlights: ['一份定义', 'Zeta / Flink / Spark', '无需重写连接器'],
+                    layout: 'wide',
                 },
             ],
         },
@@ -559,30 +559,6 @@ const HOME_COPY = {
             ],
             more: '还包括：MongoDB / Redis / Elasticsearch / Neo4j / Cassandra / HBase / Druid / HugeGraph / IoTDB / InfluxDB / DynamoDB / Milvus / Qdrant ...',
         },
-        flow: {
-            eyebrow: '工作方式',
-            titleLead: 'Extract. transform. Load. Transform.',
-            titleAccent: '保持简单',
-            lead: '一份配置文件即可定义整条 EtLT pipeline，从抽取、轻量转换到目标写入。',
-            steps: [
-                {
-                    label: '01 抽取',
-                    title: '从任何地方读取',
-                    tags: ['MySQL-CDC', 'Kafka', 'PostgreSQL', 'MongoDB', 'Oracle', 'S3', 'Hive', '+193 more'],
-                },
-                {
-                    label: '02 轻量转换',
-                    title: '在链路中完成清洗与增强',
-                    tags: ['SQL Transform', 'FieldMapper', 'Copy', 'Replace', 'FieldEncrypt', 'Split', 'FilterRowKind', 'Jsonpath'],
-                    highlight: true,
-                },
-                {
-                    label: '03 装载',
-                    title: '写入任何目标',
-                    tags: ['ClickHouse', 'Iceberg', 'Doris', 'StarRocks', 'Paimon', 'Kafka', 'Redis', '+193 more'],
-                },
-            ],
-        },
         code: {
             eyebrow: '设计上就是简单',
             titleLead: '一份配置文件',
@@ -593,9 +569,9 @@ const HOME_COPY = {
             fileName: 'mysql-cdc-to-clickhouse.conf',
         },
         cta: {
-            titleLead: '开始让数据流动',
-            titleAccent: '不受限制',
-            lead: '开源、Apache License、永久免费。为真正的生产团队提供稳定的数据集成底座，而不是一套只能演示的页面。',
+            titleLead: '一份 pipeline 定义',
+            titleAccent: '运行在 Zeta、Flink 或 Spark 上',
+            lead: 'SeaTunnel 把 CDC、模式演进、多模态数据流动与生产级可靠性统一到一个 Apache License 的集成层里。',
             primaryButton: '快速开始',
             secondaryButton: 'GitHub',
             tertiaryButton: 'Slack 入口',
@@ -719,6 +695,12 @@ export default function Home() {
     const heroWarpCanvasRef = useRef(null);
     const ctaWarpCanvasRef = useRef(null);
     const flowCanvasRef = useRef(null);
+    const architectureBoardRef = useRef(null);
+    const architectureGridRef = useRef(null);
+    const architectureSvgRef = useRef(null);
+    const architectureEngineRef = useRef(null);
+    const architectureSourceRefs = useRef([]);
+    const architectureTargetRefs = useRef([]);
 
     const language = isBrowser
         ? (window.location.pathname.startsWith('/zh-CN/') ? 'zh-CN' : 'en')
@@ -913,6 +895,11 @@ export default function Home() {
             let frame = 0;
             let frameId;
 
+            const smoothStep = (value) => {
+                const clamped = Math.min(Math.max(value, 0), 1);
+                return clamped * clamped * (3 - (2 * clamped));
+            };
+
             function resize() {
                 const deviceRatio = window.devicePixelRatio || 1;
                 canvas.width = canvas.offsetWidth * deviceRatio;
@@ -932,8 +919,10 @@ export default function Home() {
                 const dash = 10;
                 const gap = 8;
                 const period = dash + gap;
+                const edgeSoftness = Math.min(width * 0.09, 116);
+                const travelPadding = edgeSoftness + 34;
                 // Keep the divider motion readable instead of turning it into a noisy scan line.
-                const offset = -(frame * 0.26) % period;
+                const offset = -(frame * 0.13) % period;
                 const gradient = context.createLinearGradient(0, 0, width, 0);
 
                 gradient.addColorStop(0, 'rgba(66,184,236,0)');
@@ -956,14 +945,21 @@ export default function Home() {
 
                 const pulseCount = 5;
                 for (let index = 0; index < pulseCount; index += 1) {
-                    const phase = ((frame / 380) + (index / pulseCount)) % 1;
-                    const pulseX = phase * width;
+                    const phase = ((frame / 760) + (index / pulseCount)) % 1;
+                    const pulseX = (-travelPadding) + (phase * (width + (travelPadding * 2)));
+                    const edgeAlpha = Math.min(
+                        smoothStep(pulseX / edgeSoftness),
+                        smoothStep((width - pulseX) / edgeSoftness),
+                    );
+                    if (edgeAlpha <= 0.001) {
+                        continue;
+                    }
                     const hueRatio = width > 0 ? (pulseX / width) : 0;
                     const hue = 197 + (hueRatio * 130);
                     const radius = 11 + (Math.sin((frame * 0.022) + index) * 2);
                     const pulseGradient = context.createRadialGradient(pulseX, centerY, 0, pulseX, centerY, radius * 2.2);
-                    pulseGradient.addColorStop(0, `hsla(${hue},90%,78%,1)`);
-                    pulseGradient.addColorStop(0.35, `hsla(${hue},85%,68%,.55)`);
+                    pulseGradient.addColorStop(0, `hsla(${hue},90%,78%,${edgeAlpha})`);
+                    pulseGradient.addColorStop(0.35, `hsla(${hue},85%,68%,${edgeAlpha * 0.55})`);
                     pulseGradient.addColorStop(1, `hsla(${hue},85%,65%,0)`);
 
                     context.beginPath();
@@ -995,6 +991,218 @@ export default function Home() {
             };
         };
 
+        const startArchitecturePipelines = () => {
+            const grid = architectureGridRef.current;
+            const svg = architectureSvgRef.current;
+            const engine = architectureEngineRef.current;
+            const engineCard = engine?.querySelector('.st-home-architecture-engine-box');
+            if (!grid || !svg || !engine || !engineCard) {
+                return () => {};
+            }
+
+            let syncFrame = 0;
+            let resizeObserver;
+            const pipeIds = [
+                'left-top',
+                'left-mid',
+                'left-bot',
+                'right-top',
+                'right-mid',
+                'right-bot',
+                'flow-top',
+                'flow-mid',
+                'flow-bot',
+            ];
+
+            const setPath = (id, d) => {
+                const path = svg.querySelector(`#${id}`);
+                if (path) {
+                    path.setAttribute('d', d);
+                }
+            };
+
+            const clearPaths = () => {
+                pipeIds.forEach((id) => setPath(id, 'M 0 0 H 0'));
+            };
+
+            const buildHorizontalPath = (fromX, toX, y) => `M ${fromX} ${y} H ${toX}`;
+
+            const syncPipelines = () => {
+                syncFrame = 0;
+                const layoutRect = grid.getBoundingClientRect();
+                if (!layoutRect.width || !layoutRect.height) {
+                    clearPaths();
+                    return;
+                }
+
+                svg.setAttribute('viewBox', `0 0 ${layoutRect.width} ${layoutRect.height}`);
+
+                if (window.innerWidth <= 1024) {
+                    clearPaths();
+                    return;
+                }
+
+                const engineRect = engineCard.getBoundingClientRect();
+                if (!engineRect.width || !engineRect.height) {
+                    clearPaths();
+                    return;
+                }
+
+                const toLocal = (rect) => ({
+                    left: rect.left - layoutRect.left,
+                    right: rect.right - layoutRect.left,
+                    top: rect.top - layoutRect.top,
+                    bottom: rect.bottom - layoutRect.top,
+                    centerY: rect.top - layoutRect.top + (rect.height / 2),
+                });
+
+                const engineLocal = toLocal(engineRect);
+                const pipeGlobalShift = 2;
+                const leftEnd = engineLocal.left - 18 + pipeGlobalShift;
+                const rightStart = engineLocal.right + 18 + pipeGlobalShift;
+                const rightPipeShift = -9;
+
+                ARCHITECTURE_ROW_KEYS.forEach((key, index) => {
+                    const sourceEl = architectureSourceRefs.current[index];
+                    const targetEl = architectureTargetRefs.current[index];
+                    if (!sourceEl || !targetEl) {
+                        setPath(`left-${key}`, 'M 0 0 H 0');
+                        setPath(`right-${key}`, 'M 0 0 H 0');
+                        setPath(`flow-${key}`, 'M 0 0 H 0');
+                        return;
+                    }
+
+                    const sourceLocal = toLocal(sourceEl.getBoundingClientRect());
+                    const targetLocal = toLocal(targetEl.getBoundingClientRect());
+                    setPath(`left-${key}`, buildHorizontalPath(sourceLocal.right + 6 + pipeGlobalShift, leftEnd, sourceLocal.centerY));
+                    setPath(
+                        `right-${key}`,
+                        buildHorizontalPath(
+                            rightStart + rightPipeShift,
+                            targetLocal.left - 6 + rightPipeShift + pipeGlobalShift,
+                            targetLocal.centerY,
+                        ),
+                    );
+
+                    const laneY = ((sourceLocal.centerY + targetLocal.centerY) / 2).toFixed(2);
+                    const sourceRight = (sourceLocal.right + 6 + pipeGlobalShift).toFixed(2);
+                    const targetLeft = (targetLocal.left - 6 + rightPipeShift + pipeGlobalShift).toFixed(2);
+                    // Keep the motion path continuous so a single pulse can pass behind the center card.
+                    setPath(`flow-${key}`, buildHorizontalPath(sourceRight, targetLeft, laneY));
+                });
+            };
+
+            const requestSync = () => {
+                if (syncFrame) {
+                    window.cancelAnimationFrame(syncFrame);
+                }
+                syncFrame = window.requestAnimationFrame(syncPipelines);
+            };
+
+            const observedElements = [
+                grid,
+                engineCard,
+                ...architectureSourceRefs.current,
+                ...architectureTargetRefs.current,
+            ].filter(Boolean);
+
+            if (window.ResizeObserver) {
+                resizeObserver = new ResizeObserver(requestSync);
+                observedElements.forEach((element) => resizeObserver.observe(element));
+            }
+
+            clearPaths();
+            requestSync();
+            window.addEventListener('resize', requestSync);
+
+            return () => {
+                if (syncFrame) {
+                    window.cancelAnimationFrame(syncFrame);
+                }
+                window.removeEventListener('resize', requestSync);
+                if (resizeObserver) {
+                    resizeObserver.disconnect();
+                }
+            };
+        };
+
+        const startArchitectureHover = () => {
+            const board = architectureBoardRef.current;
+            const engine = architectureEngineRef.current;
+            const engineCard = engine?.querySelector('.st-home-architecture-engine-box');
+            if (!board || !engine || !engineCard) {
+                return () => {};
+            }
+
+            const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+            const resetBoard = () => {
+                board.classList.remove('is-hovering');
+                board.style.setProperty('--tilt-x', '0deg');
+                board.style.setProperty('--tilt-y', '0deg');
+                board.style.setProperty('--spot-x', '50%');
+                board.style.setProperty('--spot-y', '50%');
+            };
+
+            const resetEngine = () => {
+                engine.classList.remove('is-hovering');
+                engineCard.style.setProperty('--engine-shift-x', '0px');
+                engineCard.style.setProperty('--engine-shift-y', '0px');
+                engineCard.style.setProperty('--engine-spot-x', '50%');
+                engineCard.style.setProperty('--engine-spot-y', '12%');
+            };
+
+            if (reduceMotion) {
+                resetBoard();
+                resetEngine();
+                return () => {};
+            }
+
+            const handleBoardMove = (event) => {
+                const rect = board.getBoundingClientRect();
+                const px = (event.clientX - rect.left) / rect.width;
+                const py = (event.clientY - rect.top) / rect.height;
+                const tiltY = (px - 0.5) * 7.5;
+                const tiltX = (0.5 - py) * 6.5;
+
+                board.classList.add('is-hovering');
+                board.style.setProperty('--tilt-x', `${tiltX.toFixed(2)}deg`);
+                board.style.setProperty('--tilt-y', `${tiltY.toFixed(2)}deg`);
+                board.style.setProperty('--spot-x', `${(px * 100).toFixed(2)}%`);
+                board.style.setProperty('--spot-y', `${(py * 100).toFixed(2)}%`);
+            };
+
+            const handleEngineMove = (event) => {
+                const rect = engine.getBoundingClientRect();
+                const px = (event.clientX - rect.left) / rect.width;
+                const py = (event.clientY - rect.top) / rect.height;
+                const shiftX = (px - 0.5) * 12;
+                const shiftY = (py - 0.5) * 10;
+
+                engine.classList.add('is-hovering');
+                engineCard.style.setProperty('--engine-shift-x', `${shiftX.toFixed(2)}px`);
+                engineCard.style.setProperty('--engine-shift-y', `${shiftY.toFixed(2)}px`);
+                engineCard.style.setProperty('--engine-spot-x', `${(px * 100).toFixed(2)}%`);
+                engineCard.style.setProperty('--engine-spot-y', `${(py * 100).toFixed(2)}%`);
+            };
+
+            board.addEventListener('pointermove', handleBoardMove);
+            board.addEventListener('pointerleave', resetBoard);
+            engine.addEventListener('pointermove', handleEngineMove);
+            engine.addEventListener('pointerleave', resetEngine);
+            resetBoard();
+            resetEngine();
+
+            return () => {
+                board.removeEventListener('pointermove', handleBoardMove);
+                board.removeEventListener('pointerleave', resetBoard);
+                engine.removeEventListener('pointermove', handleEngineMove);
+                engine.removeEventListener('pointerleave', resetEngine);
+                resetBoard();
+                resetEngine();
+            };
+        };
+
         const stopHeroWarpCanvas = startWarpCanvas(heroWarpCanvasRef, {
             alphaMultiplier: 0.48,
             lineCount: 84,
@@ -1003,6 +1211,8 @@ export default function Home() {
         });
         const stopCtaWarpCanvas = startWarpCanvas(ctaWarpCanvasRef);
         const stopFlowCanvas = startFlowCanvas();
+        const stopArchitecturePipelines = startArchitecturePipelines();
+        const stopArchitectureHover = startArchitectureHover();
 
         return () => {
             document.body.classList.remove('seatunnel-homepage-page');
@@ -1016,6 +1226,8 @@ export default function Home() {
             stopHeroWarpCanvas();
             stopCtaWarpCanvas();
             stopFlowCanvas();
+            stopArchitecturePipelines();
+            stopArchitectureHover();
             visibilityHandlers.forEach((cleanup) => cleanup());
         };
     }, [isBrowser]);
@@ -1123,146 +1335,184 @@ export default function Home() {
                     </div>
                 </div>
 
-                <div className="st-home-hero-visual">
-                    <div className="st-home-pipeline-visual">
-                        <div className="st-home-pipeline-column">
-                            <div className="st-home-pipeline-label">Sources</div>
-                            {HERO_SOURCES.map((item) => (
-                                <div key={item.name} className="st-home-pipeline-item">
-                                    <span className={`st-home-pipeline-dot st-home-dot-${item.colorClass}`}></span>
-                                    <span>{item.name}</span>
-                                </div>
-                            ))}
-                            <div className="st-home-pipeline-item st-home-pipeline-item-muted">+195 more sources</div>
-                        </div>
-
-                        <div className="st-home-pipeline-tunnel">
-                            <div className="st-home-pipeline-tunnel-label">In</div>
-                            <div className="st-home-tunnel-line"></div>
-                            <div className="st-home-tunnel-line"></div>
-                            <div className="st-home-tunnel-line"></div>
-                        </div>
-
-                        <div className="st-home-pipeline-center">
-                            <div className="st-home-pipeline-tunnel-label st-home-pipeline-center-label">SeaTunnel</div>
-                            <div className="st-home-pipeline-center-icon">
-                                <img src={logoPath} alt="SeaTunnel" />
-                            </div>
-                            <div className="st-home-pipeline-center-name">EtLT / Route</div>
-                        </div>
-
-                        <div className="st-home-pipeline-tunnel">
-                            <div className="st-home-pipeline-tunnel-label">Out</div>
-                            <div className="st-home-tunnel-line"></div>
-                            <div className="st-home-tunnel-line"></div>
-                            <div className="st-home-tunnel-line"></div>
-                        </div>
-
-                        <div className="st-home-pipeline-column">
-                            <div className="st-home-pipeline-label">Sinks</div>
-                            {HERO_SINKS.map((item) => (
-                                <div key={item.name} className="st-home-pipeline-item">
-                                    <span className={`st-home-pipeline-dot st-home-dot-${item.colorClass}`}></span>
-                                    <span>{item.name}</span>
-                                </div>
-                            ))}
-                            <div className="st-home-pipeline-item st-home-pipeline-item-muted">+195 more sinks</div>
-                        </div>
-                    </div>
-                </div>
-
                 <div className="st-home-hero-fade"></div>
             </section>
 
-            <div className="st-home-stats-divider">
-                <canvas ref={flowCanvasRef} className="st-home-flow-canvas"></canvas>
-            </div>
-
-            <section className="st-home-stats">
-                {content.stats.map((stat) => (
-                    <div key={stat.label} className="st-home-stat st-home-rv">
-                        <div className="st-home-stat-number">{stat.value}</div>
-                        <div className="st-home-stat-label">{stat.label}</div>
-                    </div>
-                ))}
-            </section>
-
-            <section className="st-home-section st-home-architecture">
+            <section className="st-home-stats-band">
                 <div className="st-home-container">
-                    <p className="st-home-eyebrow st-home-rv">{content.architecture.eyebrow}</p>
-                    <h2 className="st-home-section-title st-home-rv">
-                        {content.architecture.titleLead} <span className="st-home-gradient st-home-meteor-line">{content.architecture.titleAccent}</span>
-                    </h2>
-                    <p className="st-home-section-lead st-home-rv">{content.architecture.lead}</p>
-
-                    <div className="st-home-architecture-header st-home-rv">
-                        <div>{content.architecture.headers.sources}</div>
-                        <div></div>
-                        <div className="st-home-architecture-header-center">{content.architecture.headers.engine}</div>
-                        <div></div>
-                        <div className="st-home-architecture-header-right">{content.architecture.headers.targets}</div>
+                    <div className="st-home-stats-divider">
+                        <canvas ref={flowCanvasRef} className="st-home-flow-canvas"></canvas>
                     </div>
 
-                    <div className="st-home-architecture-grid st-home-rv">
-                        <div className="st-home-architecture-engine">
-                            <div className="st-home-architecture-engine-box">
-                                <img src={logoPath} alt="SeaTunnel" />
-                                <div className="st-home-architecture-engine-name">SeaTunnel</div>
-                                <div className="st-home-architecture-engine-word">
-                                    <span className="st-home-architecture-engine-e">E</span>
-                                    <span className="st-home-architecture-engine-t-small">t</span>
-                                    <span className="st-home-architecture-engine-l">L</span>
-                                    <span className="st-home-architecture-engine-t">T</span>
-                                </div>
-                                <div className="st-home-architecture-engine-badges">
-                                    {content.architecture.engineBadges.map((badge) => (
-                                        <span key={badge}>{badge}</span>
-                                    ))}
-                                </div>
+                    <div className="st-home-stats st-home-rv">
+                        {content.stats.map((stat) => (
+                            <div key={stat.label} className="st-home-stat">
+                                <div className="st-home-stat-number">{stat.value}</div>
+                                <div className="st-home-stat-label">{stat.label}</div>
                             </div>
-                        </div>
-
-                        {content.architecture.rows.map((row) => (
-                            <React.Fragment key={`${row.source.title}-${row.target.title}`}>
-                                <div className="st-home-architecture-card">
-                                    <div className="st-home-architecture-card-head">
-                                        <span className={`st-home-architecture-card-dot st-home-dot-${row.source.dotClass}`}></span>
-                                        <span>{row.source.title}</span>
-                                        <span className="st-home-architecture-card-tag">{row.source.tag}</span>
-                                    </div>
-                                    <div className="st-home-architecture-chip-list">
-                                        {row.source.chips.map((chip) => (
-                                            <span key={chip} className="st-home-architecture-chip">{chip}</span>
-                                        ))}
-                                    </div>
-                                </div>
-                                <div className="st-home-architecture-connector">
-                                    <div className="st-home-architecture-line"></div>
-                                    <span>&gt;</span>
-                                </div>
-                                <div className="st-home-architecture-connector st-home-architecture-connector-right">
-                                    <div className="st-home-architecture-line"></div>
-                                    <span>&gt;</span>
-                                </div>
-                                <div className="st-home-architecture-card">
-                                    <div className="st-home-architecture-card-head">
-                                        <span className={`st-home-architecture-card-dot st-home-dot-${row.target.dotClass}`}></span>
-                                        <span>{row.target.title}</span>
-                                        <span className="st-home-architecture-card-tag">{row.target.tag}</span>
-                                    </div>
-                                    <div className="st-home-architecture-chip-list">
-                                        {row.target.chips.map((chip) => (
-                                            <span key={chip} className="st-home-architecture-chip">{chip}</span>
-                                        ))}
-                                    </div>
-                                </div>
-                            </React.Fragment>
                         ))}
                     </div>
                 </div>
             </section>
 
-            <section className="st-home-section">
+            <section className="st-home-section st-home-architecture">
+                <div className="st-home-container st-home-container-wide">
+                    <p className="st-home-eyebrow st-home-rv">{content.architecture.eyebrow}</p>
+                    <h2 className="st-home-section-title st-home-rv">
+                        {content.architecture.titleLead} <span className="st-home-gradient">{content.architecture.titleAccent}</span>
+                    </h2>
+                    <p className="st-home-section-lead st-home-rv">{content.architecture.lead}</p>
+
+                    <div className="st-home-architecture-board st-home-rv" ref={architectureBoardRef}>
+                        <div className="st-home-architecture-board-inner">
+                            <div className="st-home-architecture-header">
+                                <div className="st-home-architecture-stage">
+                                    <span className="st-home-architecture-stage-index">01</span>
+                                    <span className="st-home-architecture-stage-label">
+                                        {stripArchitectureStageIndex(content.architecture.headers.sources)}
+                                    </span>
+                                </div>
+                                <div className="st-home-architecture-stage st-home-architecture-stage-center">
+                                    <span className="st-home-architecture-stage-index">02</span>
+                                    <span className="st-home-architecture-stage-label st-home-architecture-stage-label-engine">
+                                        {stripArchitectureStageIndex(content.architecture.headers.engine)}
+                                    </span>
+                                </div>
+                                <div className="st-home-architecture-stage st-home-architecture-stage-right">
+                                    <span className="st-home-architecture-stage-index">03</span>
+                                    <span className="st-home-architecture-stage-label">
+                                        {stripArchitectureStageIndex(content.architecture.headers.targets)}
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div className="st-home-architecture-grid" ref={architectureGridRef}>
+                                <div className="st-home-architecture-pipelines" aria-hidden="true">
+                                    <svg ref={architectureSvgRef} preserveAspectRatio="none" role="presentation">
+                                        <defs>
+                                            <path id="left-top"></path>
+                                            <path id="left-mid"></path>
+                                            <path id="left-bot"></path>
+                                            <path id="right-top"></path>
+                                            <path id="right-mid"></path>
+                                            <path id="right-bot"></path>
+                                            <path id="flow-top"></path>
+                                            <path id="flow-mid"></path>
+                                            <path id="flow-bot"></path>
+                                        </defs>
+
+                                        {ARCHITECTURE_ROW_KEYS.map((key) => (
+                                            <React.Fragment key={`pipe-left-${key}`}>
+                                                <use href={`#left-${key}`} className="st-home-architecture-pipe-base"></use>
+                                                <use href={`#left-${key}`} className="st-home-architecture-pipe-edge"></use>
+                                                <use href={`#left-${key}`} className="st-home-architecture-pipe-core"></use>
+                                            </React.Fragment>
+                                        ))}
+
+                                        {ARCHITECTURE_ROW_KEYS.map((key) => (
+                                            <React.Fragment key={`pipe-right-${key}`}>
+                                                <use href={`#right-${key}`} className="st-home-architecture-pipe-base"></use>
+                                                <use href={`#right-${key}`} className="st-home-architecture-pipe-edge"></use>
+                                                <use href={`#right-${key}`} className="st-home-architecture-pipe-core"></use>
+                                            </React.Fragment>
+                                        ))}
+
+                                        {ARCHITECTURE_ROW_KEYS.map((key, index) => {
+                                            const duration = `${6.5 + (index * 0.3)}s`;
+                                            const begin = `${[-1.45, -4.15, -5.7][index]}s`;
+                                            return (
+                                                <React.Fragment key={`pulse-${key}`}>
+                                                    <circle r="7" className="st-home-architecture-pulse st-home-architecture-pulse-ring">
+                                                        <animateMotion dur={duration} begin={begin} repeatCount="indefinite">
+                                                            <mpath href={`#flow-${key}`}></mpath>
+                                                        </animateMotion>
+                                                    </circle>
+                                                    <circle r="4" className="st-home-architecture-pulse st-home-architecture-pulse-core">
+                                                        <animateMotion dur={duration} begin={begin} repeatCount="indefinite">
+                                                            <mpath href={`#flow-${key}`}></mpath>
+                                                        </animateMotion>
+                                                    </circle>
+                                                </React.Fragment>
+                                            );
+                                        })}
+                                    </svg>
+                                </div>
+
+                                <div className="st-home-architecture-column">
+                                    {content.architecture.rows.map((row, index) => (
+                                        <div
+                                            key={`source-${row.source.title}`}
+                                            className="st-home-architecture-card"
+                                            data-pipe-source={ARCHITECTURE_ROW_KEYS[index]}
+                                            ref={(node) => {
+                                                architectureSourceRefs.current[index] = node;
+                                            }}>
+                                            <div className="st-home-architecture-card-head">
+                                                <span className={`st-home-architecture-card-dot st-home-dot-${row.source.dotClass}`}></span>
+                                                <span>{row.source.title}</span>
+                                                <span className="st-home-architecture-card-tag">{row.source.tag}</span>
+                                            </div>
+                                            <div className="st-home-architecture-chip-list">
+                                                {row.source.chips.map((chip) => (
+                                                    <span key={chip} className="st-home-architecture-chip">{chip}</span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+
+                                <div className="st-home-architecture-engine" ref={architectureEngineRef}>
+                                    <div className="st-home-architecture-engine-box">
+                                        <div className="st-home-architecture-engine-logo">
+                                            <img src={logoPath} alt="SeaTunnel" />
+                                        </div>
+                                        <div className="st-home-architecture-engine-name">SeaTunnel</div>
+                                        <div className="st-home-architecture-engine-word">
+                                            <span className="st-home-architecture-engine-e">E</span>
+                                            <span className="st-home-architecture-engine-t-small">t</span>
+                                            <span className="st-home-architecture-engine-l">L</span>
+                                            <span className="st-home-architecture-engine-t">T</span>
+                                        </div>
+                                        <div className="st-home-architecture-engine-pillars">
+                                            {content.architecture.enginePillars.map((item) => (
+                                                <div key={item.label} className="st-home-architecture-engine-pillar">
+                                                    <strong>{item.label}</strong>
+                                                    <span>{item.value}</span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className="st-home-architecture-column">
+                                    {content.architecture.rows.map((row, index) => (
+                                        <div
+                                            key={`target-${row.target.title}`}
+                                            className="st-home-architecture-card"
+                                            data-pipe-target={ARCHITECTURE_ROW_KEYS[index]}
+                                            ref={(node) => {
+                                                architectureTargetRefs.current[index] = node;
+                                            }}>
+                                            <div className="st-home-architecture-card-head">
+                                                <span className={`st-home-architecture-card-dot st-home-dot-${row.target.dotClass}`}></span>
+                                                <span>{row.target.title}</span>
+                                                <span className="st-home-architecture-card-tag">{row.target.tag}</span>
+                                            </div>
+                                            <div className="st-home-architecture-chip-list">
+                                                {row.target.chips.map((chip) => (
+                                                    <span key={chip} className="st-home-architecture-chip">{chip}</span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="st-home-section st-home-features-section">
                 <div className="st-home-container">
                     <p className="st-home-eyebrow st-home-rv">{content.features.eyebrow}</p>
                     <h2 className="st-home-section-title st-home-rv">{content.features.title}</h2>
@@ -1270,7 +1520,6 @@ export default function Home() {
 
                     <div className="st-home-feature-grid">
                         <article className="st-home-feature-card st-home-feature-card-wide st-home-rv" onMouseMove={handleFeatureGlow}>
-                            <div className="st-home-feature-accent"></div>
                             <div className="st-home-feature-copy st-home-feature-copy-wide">
                                 <div className="st-home-feature-number">{content.features.schema.number}</div>
                                 <div className={`st-home-feature-icon st-home-feature-icon-${content.features.schema.accent}`}>
@@ -1285,15 +1534,23 @@ export default function Home() {
                         {content.features.cards.map((card) => (
                             <article
                                 key={card.number}
-                                className="st-home-feature-card st-home-rv"
+                                className={`st-home-feature-card st-home-rv${card.layout === 'wide' ? ' st-home-feature-card-span-2' : ''}`}
                                 onMouseMove={handleFeatureGlow}>
-                                <div className="st-home-feature-accent"></div>
                                 <div className="st-home-feature-number">{card.number}</div>
                                 <div className={`st-home-feature-icon st-home-feature-icon-${card.accent}`}>
                                     <FeatureIcon icon={card.icon} />
                                 </div>
                                 <h3 className="st-home-feature-title">{card.title}</h3>
                                 <p className="st-home-feature-description">{card.description}</p>
+                                {card.highlights?.length ? (
+                                    <div className="st-home-feature-highlights">
+                                        {card.highlights.map((item) => (
+                                            <span key={item} className="st-home-feature-highlight">
+                                                {item}
+                                            </span>
+                                        ))}
+                                    </div>
+                                ) : null}
                             </article>
                         ))}
                     </div>
@@ -1335,38 +1592,6 @@ export default function Home() {
                     </div>
 
                     <div className="st-home-connector-more st-home-rv">{content.connectors.more}</div>
-                </div>
-            </section>
-
-            <section className="st-home-section">
-                <div className="st-home-container">
-                    <p className="st-home-eyebrow st-home-rv">{content.flow.eyebrow}</p>
-                    <h2 className="st-home-section-title st-home-rv">
-                        {content.flow.titleLead}<br />
-                        <span className="st-home-gradient st-home-meteor-line">{content.flow.titleAccent}</span>
-                    </h2>
-                    <p className="st-home-section-lead st-home-rv">{content.flow.lead}</p>
-
-                    <div className="st-home-flow-grid st-home-rv">
-                        {content.flow.steps.map((step, index) => (
-                            <React.Fragment key={step.label}>
-                                <article className={`st-home-flow-card${step.highlight ? ' st-home-flow-card-highlight' : ''}`}>
-                                    <div className="st-home-flow-card-label">{step.label}</div>
-                                    <h3 className="st-home-flow-card-title">{step.title}</h3>
-                                    <div className="st-home-flow-card-tags">
-                                        {step.tags.map((tag) => (
-                                            <span key={tag} className={`st-home-flow-tag${step.highlight ? ' st-home-flow-tag-highlight' : ''}`}>{tag}</span>
-                                        ))}
-                                    </div>
-                                </article>
-                                {index < content.flow.steps.length - 1 ? (
-                                    <div className="st-home-flow-arrow" aria-hidden="true">
-                                        <ArrowRightIcon />
-                                    </div>
-                                ) : null}
-                            </React.Fragment>
-                        ))}
-                    </div>
                 </div>
             </section>
 
@@ -1413,7 +1638,7 @@ export default function Home() {
                 <div className="st-home-cta-inner st-home-rv">
                     <h2 className="st-home-cta-title">
                         {content.cta.titleLead}<br />
-                        <span className="st-home-gradient st-home-meteor-line">{content.cta.titleAccent}</span>
+                        <span className="st-home-gradient">{content.cta.titleAccent}</span>
                     </h2>
                     <p className="st-home-cta-subtitle">{content.cta.lead}</p>
                     <div className="st-home-cta-actions">

--- a/src/pages/home/index.less
+++ b/src/pages/home/index.less
@@ -218,6 +218,8 @@ body.seatunnel-homepage-page .index-nav .dropdown__menu .dropdown__link {
   --bteal: rgba(93, 184, 226, 0.16);
   --brand-gradient: linear-gradient(90deg, #5db8e2 0%, #6b76d6 56%, #bb56b6 100%);
   --brand-gradient-soft: linear-gradient(145deg, rgba(93, 184, 226, 0.16) 0%, rgba(107, 118, 214, 0.11) 58%, rgba(187, 86, 182, 0.06) 100%);
+  --brand-gradient-cool: linear-gradient(90deg, #59b8e8 0%, #75a2eb 54%, #61d0c7 100%);
+  --brand-gradient-cool-soft: linear-gradient(145deg, rgba(89, 184, 232, 0.16) 0%, rgba(117, 162, 235, 0.12) 56%, rgba(97, 208, 199, 0.08) 100%);
   --shadow: 0 40px 80px rgba(0, 0, 0, 0.5);
   --r-sm: 10px;
   --r-md: 16px;
@@ -261,6 +263,10 @@ html[data-theme='light'] .st-home {
 .st-home-container {
   width: min(1200px, calc(100% - 48px));
   margin: 0 auto;
+}
+
+.st-home-container-wide {
+  width: min(1480px, calc(100% - 56px));
 }
 
 .st-home-gradient {
@@ -536,8 +542,7 @@ html[data-theme='light'] .st-home {
   animation: st-home-orb-3 14s ease-in-out infinite;
 }
 
-.st-home-hero-content,
-.st-home-hero-visual {
+.st-home-hero-content {
   position: relative;
   z-index: 10;
 }
@@ -595,7 +600,7 @@ html[data-theme='light'] .st-home {
 }
 
 .st-home-hero-subtitle {
-  max-width: 620px;
+  max-width: 700px;
   margin: 0 auto 2.5rem;
   font-size: clamp(1.08rem, 1.75vw, 1.24rem);
   line-height: 1.78;
@@ -860,6 +865,45 @@ html[data-theme='light'] .st-home {
   pointer-events: none;
 }
 
+.st-home-stats-band {
+  padding: 0 1.5rem 0.75rem;
+  background: var(--bg0);
+}
+
+.st-home-stats-shell {
+  position: relative;
+  overflow: hidden;
+  border-radius: 2rem;
+  border: 1px solid rgba(90, 150, 230, 0.16);
+  background:
+    radial-gradient(circle at 12% 20%, rgba(84, 196, 255, 0.1), transparent 24%),
+    radial-gradient(circle at 86% 22%, rgba(97, 208, 199, 0.08), transparent 26%),
+    linear-gradient(180deg, rgba(11, 19, 34, 0.98), rgba(7, 13, 24, 1));
+  box-shadow:
+    0 30px 62px rgba(2, 6, 15, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.st-home-stats-shell::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(90deg, transparent 0%, rgba(89, 184, 232, 0.08) 24%, rgba(117, 162, 235, 0.08) 52%, rgba(97, 208, 199, 0.08) 78%, transparent 100%);
+  opacity: 0.88;
+  pointer-events: none;
+}
+
+.st-home-stats-shell::after {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border-radius: 1.4rem;
+  border: 1px solid rgba(108, 168, 236, 0.08);
+  pointer-events: none;
+}
+
 .st-home-stats {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -883,12 +927,12 @@ html[data-theme='light'] .st-home {
 }
 
 .st-home-stat-number {
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
   font-size: clamp(2rem, 3.5vw, 3.25rem);
   font-weight: 800;
   line-height: 1;
   letter-spacing: -0.04em;
-  background: var(--brand-gradient);
+  background: var(--brand-gradient-cool);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -906,6 +950,16 @@ html[data-theme='light'] .st-home {
 
 .st-home-architecture {
   background: var(--bg0);
+}
+
+.st-home-features-section {
+  background: var(--bg0);
+}
+
+.st-home-architecture .st-home-gradient {
+  background-image: var(--brand-gradient-cool);
+  -webkit-background-clip: text;
+  background-clip: text;
 }
 
 .st-home-eyebrow {
@@ -939,183 +993,547 @@ html[data-theme='light'] .st-home {
   font-weight: 500;
 }
 
-.st-home-architecture-header {
-  display: grid;
-  grid-template-columns: 1fr 90px 210px 90px 1fr;
-  gap: 0;
-  margin-top: 3.5rem;
-  margin-bottom: 0.75rem;
-  color: var(--t3);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.66rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
+.st-home-architecture-board {
+  --spot-x: 50%;
+  --spot-y: 50%;
+  --tilt-x: 0deg;
+  --tilt-y: 0deg;
+  --lift-y: 0px;
+  position: relative;
+  margin-top: 3.25rem;
+  padding: 2.25rem;
+  border-radius: 2.5rem;
+  border: 1px solid rgba(90, 150, 230, 0.18);
+  background:
+    radial-gradient(circle at 14% 18%, rgba(84, 196, 255, 0.12), transparent 28%),
+    radial-gradient(circle at 84% 18%, rgba(97, 208, 199, 0.1), transparent 30%),
+    linear-gradient(180deg, rgba(11, 19, 34, 0.97), rgba(6, 13, 24, 0.99));
+  box-shadow:
+    0 36px 82px rgba(2, 6, 15, 0.46),
+    inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+  isolation: isolate;
+  transform-style: preserve-3d;
+  will-change: transform;
+  transition:
+    transform 0.5s cubic-bezier(0.18, 0.9, 0.25, 1.15),
+    box-shadow 0.35s ease,
+    border-color 0.35s ease;
+  transform: perspective(1600px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-y));
 }
 
-.st-home-architecture-header-center {
+.st-home-architecture-board::before {
+  content: '';
+  position: absolute;
+  inset: 1.625rem;
+  border-radius: 2rem;
+  border: 1px solid rgba(84, 164, 239, 0.1);
+  pointer-events: none;
+  transition: border-color 0.35s ease, opacity 0.35s ease;
+}
+
+.st-home-architecture-board::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.72;
+  background:
+    radial-gradient(circle at var(--spot-x) var(--spot-y), rgba(117, 173, 255, 0.16), transparent 24%),
+    linear-gradient(120deg, transparent 0%, rgba(101, 208, 199, 0.08) 46%, transparent 54%),
+    linear-gradient(180deg, transparent 0%, rgba(98, 142, 226, 0.05) 100%);
+  transform: translateX(-55%);
+  animation: st-home-board-shimmer 8s linear infinite;
+  transition: opacity 0.3s ease;
+}
+
+.st-home-architecture-board.is-hovering {
+  --lift-y: -6px;
+  border-color: rgba(97, 165, 244, 0.28);
+  box-shadow:
+    0 42px 94px rgba(3, 8, 18, 0.52),
+    0 18px 42px rgba(76, 128, 218, 0.18);
+}
+
+.st-home-architecture-board.is-hovering::before {
+  border-color: rgba(95, 167, 243, 0.18);
+}
+
+.st-home-architecture-board > * {
+  position: relative;
+  z-index: 1;
+}
+
+.st-home-architecture-board-inner {
+  min-height: 44.75rem;
+  padding: 1rem 0.375rem 0.25rem;
+  transform: translateZ(2px);
+}
+
+.st-home-architecture-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 20rem minmax(0, 1fr);
+  align-items: center;
+  gap: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.st-home-architecture-stage {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(196, 219, 247, 0.76);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.st-home-architecture-stage-center {
   justify-self: center;
 }
 
-.st-home-architecture-header-right {
+.st-home-architecture-stage-right {
   justify-self: end;
 }
 
-.st-home-architecture-grid {
-  display: grid;
-  grid-template-columns: 1fr 90px 210px 90px 1fr;
-  gap: 0.875rem 0;
+.st-home-architecture-stage-index {
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  border-radius: 0.625rem;
+  background: rgba(69, 139, 210, 0.2);
+  color: #8fd4f6;
+  letter-spacing: 0.08em;
+  box-shadow:
+    inset 0 0 0 1px rgba(100, 154, 236, 0.16),
+    0 10px 24px rgba(5, 10, 22, 0.24);
+}
+
+.st-home-architecture-stage-label {
+  display: inline-block;
+}
+
+.st-home-architecture-stage-label-engine {
+  text-transform: none;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.875rem;
+  font-weight: 800;
+  letter-spacing: 0.34em;
+}
+
+.st-home-architecture-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 26rem) 18rem minmax(0, 26rem);
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 1.25rem;
+  min-height: 37.5rem;
+  isolation: isolate;
+}
+
+.st-home-architecture-grid > * {
+  position: relative;
+  z-index: 2;
+}
+
+.st-home-architecture-column {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.125rem;
+  position: relative;
+  z-index: 2;
+}
+
+.st-home-architecture-pipelines {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.st-home-architecture-pipelines svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  filter: drop-shadow(0 12px 28px rgba(44, 88, 176, 0.18));
+  transition: filter 0.28s ease, opacity 0.28s ease;
+}
+
+.st-home-architecture-pipe-base {
+  fill: none;
+  stroke: rgba(78, 130, 218, 0.18);
+  stroke-width: 18;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.st-home-architecture-pipe-core {
+  fill: none;
+  stroke: rgba(240, 246, 255, 0.84);
+  stroke-width: 5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 18 20;
+  animation: st-home-dash 3.2s linear infinite;
+}
+
+.st-home-architecture-pipe-edge {
+  fill: none;
+  stroke: rgba(98, 179, 255, 0.56);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 5 22;
+  animation: st-home-dash 4.6s linear infinite;
+}
+
+.st-home-architecture-pulse {
+  filter: drop-shadow(0 0 10px rgba(84, 196, 255, 0.75));
+}
+
+.st-home-architecture-pulse-core {
+  fill: #ffffff;
+  opacity: 0.96;
+}
+
+.st-home-architecture-pulse-ring {
+  fill: rgba(84, 196, 255, 0.3);
+}
+
+.st-home-architecture-board.is-hovering .st-home-architecture-pipelines svg {
+  filter: drop-shadow(0 16px 32px rgba(75, 128, 221, 0.24));
+}
+
+.st-home-architecture-board.is-hovering .st-home-architecture-pipe-core {
+  stroke: rgba(255, 255, 255, 0.98);
+}
+
+.st-home-architecture-board.is-hovering .st-home-architecture-pipe-edge {
+  stroke: rgba(104, 182, 255, 0.74);
 }
 
 .st-home-architecture-engine {
-  grid-column: 3;
-  grid-row: 1 / 4;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.875rem;
+  perspective: 1200px;
+  z-index: 3;
 }
 
 .st-home-architecture-engine-box {
+  --engine-shift-x: 0px;
+  --engine-shift-y: 0px;
+  --engine-scale: 1;
+  --engine-spot-x: 50%;
+  --engine-spot-y: 12%;
+  position: relative;
   width: 100%;
-  padding: 2rem 1rem;
-  border-radius: var(--r-lg);
-  border: 1.5px solid rgba(66, 184, 236, 0.26);
-  background: linear-gradient(160deg, rgba(66, 184, 236, 0.08), rgba(111, 91, 255, 0.08) 55%, rgba(240, 24, 138, 0.04));
+  min-height: 27.5rem;
+  padding: 1.75rem 1.5rem 1.625rem;
+  border-radius: 2.125rem;
+  border: 1px solid rgba(105, 161, 235, 0.2);
+  background: linear-gradient(180deg, rgba(14, 24, 40, 0.95), rgba(8, 15, 28, 0.99));
+  backdrop-filter: blur(18px);
   text-align: center;
+  overflow: hidden;
+  transform-style: preserve-3d;
+  will-change: transform;
+  transition:
+    transform 0.22s ease,
+    box-shadow 0.25s ease,
+    border-color 0.25s ease;
+  transform: translate3d(var(--engine-shift-x), var(--engine-shift-y), 0) scale(var(--engine-scale));
+  box-shadow:
+    0 28px 62px rgba(2, 6, 15, 0.44),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
 
-  img {
-    width: 54px;
-    height: 54px;
-    margin: 0 auto 0.75rem;
-    object-fit: contain;
-  }
+.st-home-architecture-engine-box::before {
+  content: '';
+  position: absolute;
+  inset: 0.875rem;
+  border-radius: 1.75rem;
+  background:
+    radial-gradient(circle at var(--engine-spot-x) var(--engine-spot-y), rgba(96, 168, 255, 0.18), transparent 18%),
+    radial-gradient(circle at 20% 18%, rgba(66, 184, 236, 0.16), transparent 28%),
+    radial-gradient(circle at 80% 12%, rgba(97, 208, 199, 0.12), transparent 32%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 55%);
+  border: 1px solid rgba(97, 152, 231, 0.12);
+  pointer-events: none;
+}
+
+.st-home-architecture-engine-box::after {
+  content: '';
+  position: absolute;
+  left: 16%;
+  right: 16%;
+  top: 8.875rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(84, 162, 235, 0.12), transparent);
+  pointer-events: none;
+}
+
+.st-home-architecture-engine.is-hovering .st-home-architecture-engine-box {
+  --engine-scale: 1.022;
+  border-color: rgba(91, 156, 236, 0.24);
+  box-shadow:
+    0 34px 68px rgba(2, 6, 15, 0.5),
+    0 0 0 1px rgba(96, 156, 235, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.st-home-architecture-engine-logo {
+  width: 4.125rem;
+  height: 4.125rem;
+  margin: 0 auto 1rem;
+  padding: 0.6875rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(180deg, rgba(18, 31, 53, 0.96), rgba(13, 23, 41, 0.94));
+  box-shadow:
+    0 18px 36px rgba(2, 6, 15, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(91, 155, 236, 0.14);
+  transition: transform 0.22s ease, box-shadow 0.22s ease;
+}
+
+.st-home-architecture-engine.is-hovering .st-home-architecture-engine-logo {
+  transform: translateY(-2px);
+  box-shadow:
+    0 22px 44px rgba(2, 6, 15, 0.42),
+    0 0 28px rgba(111, 146, 255, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.st-home-architecture-engine-logo img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .st-home-architecture-engine-name {
-  font-size: 0.95rem;
+  position: relative;
+  z-index: 1;
+  margin: 0 0 0.75rem;
+  text-align: center;
+  font-size: 1.25rem;
   font-weight: 800;
-  color: var(--t1);
   letter-spacing: -0.02em;
+  color: #eef4ff;
 }
 
 .st-home-architecture-engine-word {
-  margin-top: 0.35rem;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.125rem;
   font-family: var(--ifm-font-family-monospace);
-  font-size: 1.08rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
+  font-weight: 800;
 }
 
 .st-home-architecture-engine-e {
   color: #42b8ec;
+  font-size: 1.9rem;
 }
 
 .st-home-architecture-engine-t-small {
-  font-size: 1em;
-  color: #4ade80;
-  font-weight: 700;
-  text-shadow: 0 0 10px rgba(74, 222, 128, 0.18);
-  vertical-align: baseline;
+  color: #61d0c7;
+  font-size: 1.9rem;
+  font-weight: 800;
 }
 
 .st-home-architecture-engine-l {
-  color: #7c3aed;
+  color: #75a2eb;
+  font-size: 1.9rem;
 }
 
 .st-home-architecture-engine-t {
-  color: #f0188a;
+  color: #8fd4f6;
+  font-size: 1.9rem;
 }
 
-.st-home-architecture-engine-badges {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  margin-top: 0.45rem;
+.st-home-architecture-engine-pillars {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
 
-  span {
-    font-family: var(--ifm-font-family-monospace);
-    font-size: 0.64rem;
-    font-weight: 500;
-    color: var(--t3);
-    letter-spacing: 0.04em;
-  }
+.st-home-architecture-engine-pillar {
+  position: relative;
+  padding: 0.875rem 0.875rem 0.875rem 1.125rem;
+  border-radius: 1.125rem;
+  background: rgba(15, 28, 49, 0.76);
+  border: 1px solid rgba(98, 150, 230, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition: transform 0.22s ease, border-color 0.22s ease, background 0.22s ease;
+}
+
+.st-home-architecture-engine.is-hovering .st-home-architecture-engine-pillar {
+  transform: translateY(-1px);
+  border-color: rgba(97, 152, 231, 0.22);
+  background: rgba(18, 33, 57, 0.88);
+}
+
+.st-home-architecture-engine-pillar strong {
+  display: block;
+  margin-bottom: 0.375rem;
+  color: #9fc4ff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.st-home-architecture-engine-pillar span {
+  display: block;
+  color: rgba(231, 239, 255, 0.84);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  font-weight: 700;
+}
+
+.st-home-architecture-engine-foot {
+  display: flex;
+  justify-content: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+  margin-top: 1.125rem;
+}
+
+.st-home-architecture-engine-foot span {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(97, 153, 232, 0.14);
+  color: #5c78a1;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-family: var(--ifm-font-family-monospace);
+  transition: transform 0.22s ease, border-color 0.22s ease, background 0.22s ease;
+}
+
+.st-home-architecture-engine.is-hovering .st-home-architecture-engine-foot span {
+  transform: translateY(-1px);
+  border-color: rgba(97, 153, 232, 0.2);
+  background: rgba(255, 255, 255, 0.78);
 }
 
 .st-home-architecture-card {
-  padding: 1rem 1.125rem;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: var(--r-md);
-  background: var(--bg1);
-  transition: border-color 0.2s ease;
+  position: relative;
+  min-height: 9.125rem;
+  padding: 1.375rem 1.5rem 1.25rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(180deg, rgba(12, 20, 35, 0.98), rgba(9, 15, 28, 0.96));
+  border: 1px solid rgba(94, 140, 210, 0.16);
+  box-shadow: 0 24px 46px rgba(2, 6, 15, 0.34);
+  backdrop-filter: blur(16px);
+  transition: transform 0.28s ease, box-shadow 0.28s ease, border-color 0.28s ease;
+}
+
+.st-home-architecture-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(84, 196, 255, 0.28), rgba(255, 255, 255, 0.08), rgba(97, 208, 199, 0.18));
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  opacity: 0.9;
+  transition: opacity 0.28s ease;
 }
 
 .st-home-architecture-card:hover {
-  border-color: rgba(66, 184, 236, 0.24);
+  transform: translateY(-4px);
+  box-shadow: 0 30px 58px rgba(2, 6, 15, 0.46);
+  border-color: rgba(89, 149, 229, 0.24);
+}
+
+.st-home-architecture-card:hover::before {
+  opacity: 1;
 }
 
 .st-home-architecture-card-head {
   display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.125rem;
+}
+
+.st-home-architecture-card-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  box-shadow: 0 0 18px rgba(111, 146, 255, 0.45);
+}
+
+.st-home-architecture-card-head > span:nth-child(2) {
+  flex: 1;
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: var(--t2);
+  gap: 0.625rem;
+  color: #dce8ff;
   font-family: var(--ifm-font-family-monospace);
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
+  font-size: 0.8125rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
 .st-home-architecture-card-tag {
   margin-left: auto;
-  color: var(--t3);
-  font-size: 0.62rem;
-  font-weight: 500;
-  letter-spacing: 0;
-  text-transform: none;
+  color: rgba(161, 189, 235, 0.78);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .st-home-architecture-chip-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
-  margin-top: 0.8rem;
+  gap: 0.625rem;
 }
 
 .st-home-architecture-chip {
-  padding: 2px 9px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--t2);
-  font-size: 0.8rem;
-  font-weight: 500;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid rgba(96, 136, 198, 0.18);
+  border-radius: 0.875rem;
+  background: linear-gradient(180deg, rgba(17, 28, 47, 0.92), rgba(13, 21, 37, 0.88));
+  color: #c8dcff;
+  font-size: 0.9375rem;
+  line-height: 1;
+  font-weight: 700;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
-.st-home-architecture-connector {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: rgba(138, 215, 255, 0.82);
-  font-size: 0.85rem;
-}
-
-.st-home-architecture-connector-right {
-  justify-content: flex-end;
-}
-
-.st-home-architecture-line {
-  flex: 1;
-  height: 2px;
-  background-image: repeating-linear-gradient(
-    90deg,
-    rgba(66, 184, 236, 0.7) 0px,
-    rgba(66, 184, 236, 0.7) 5px,
-    transparent 5px,
-    transparent 10px
-  );
-  background-size: 15px 2px;
-  animation: st-home-dash 0.75s linear infinite;
+@keyframes st-home-board-shimmer {
+  0% {
+    transform: translateX(-58%);
+  }
+  100% {
+    transform: translateX(72%);
+  }
 }
 
 .st-home-feature-grid {
@@ -1128,6 +1546,8 @@ html[data-theme='light'] .st-home {
 .st-home-feature-card {
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
   padding: 2rem;
   border: 1px solid rgba(255, 255, 255, 0.07);
   border-radius: var(--r-lg);
@@ -1139,7 +1559,7 @@ html[data-theme='light'] .st-home {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(260px circle at var(--mx, 50%) var(--my, 50%), rgba(111, 91, 255, 0.08), transparent 60%);
+  background: radial-gradient(260px circle at var(--mx, 50%) var(--my, 50%), rgba(89, 184, 232, 0.08), transparent 60%);
   opacity: 0;
   transition: opacity 0.3s ease;
 }
@@ -1161,23 +1581,16 @@ html[data-theme='light'] .st-home {
   align-items: center;
 }
 
+.st-home-feature-card-span-2 {
+  grid-column: span 2;
+}
+
+.st-home-feature-card-span-2 .st-home-feature-description {
+  max-width: 38rem;
+}
+
 .st-home-feature-copy-wide {
   align-self: start;
-}
-
-.st-home-feature-accent {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, #5db8e2 28%, #6b76d6 74%, transparent);
-  opacity: 0;
-  transition: opacity 0.25s ease;
-}
-
-.st-home-feature-card:hover .st-home-feature-accent {
-  opacity: 1;
 }
 
 .st-home-feature-number {
@@ -1215,6 +1628,26 @@ html[data-theme='light'] .st-home {
   max-width: 360px;
 }
 
+.st-home-feature-highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.st-home-feature-highlight {
+  padding: 0.38rem 0.72rem;
+  border-radius: 999px;
+  border: 1px solid rgba(104, 148, 220, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(219, 231, 248, 0.88);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .st-home-feature-icon {
   width: 44px;
   height: 44px;
@@ -1231,8 +1664,8 @@ html[data-theme='light'] .st-home {
 }
 
 .st-home-feature-icon-blue {
-  background: var(--b2);
-  border: 1px solid rgba(111, 91, 255, 0.24);
+  background: rgba(89, 184, 232, 0.1);
+  border: 1px solid rgba(117, 162, 235, 0.22);
 }
 
 .st-home-feature-icon-teal {
@@ -1246,8 +1679,8 @@ html[data-theme='light'] .st-home {
 }
 
 .st-home-feature-icon-violet {
-  background: rgba(111, 91, 255, 0.1);
-  border: 1px solid rgba(111, 91, 255, 0.24);
+  background: rgba(93, 184, 226, 0.1);
+  border: 1px solid rgba(93, 184, 226, 0.22);
 }
 
 .st-home-schema-demo {
@@ -1710,7 +2143,7 @@ html[data-theme='light'] .st-home {
   width: 0;
   height: 3px;
   border-radius: 2px;
-  background: var(--brand-gradient);
+  background: var(--brand-gradient-cool);
   animation: st-home-meteor-grow 0.95s cubic-bezier(0.22, 0.8, 0.18, 1) both;
   animation-play-state: paused;
 }
@@ -1723,7 +2156,7 @@ html[data-theme='light'] .st-home {
   width: 60px;
   height: 12px;
   border-radius: 50%;
-  background: radial-gradient(ellipse 70% 55% at 82% 50%, rgba(255, 255, 255, 0.96) 0%, rgba(200, 120, 255, 0.6) 38%, rgba(240, 24, 138, 0.25) 65%, transparent 100%);
+  background: radial-gradient(ellipse 70% 55% at 82% 50%, rgba(255, 255, 255, 0.96) 0%, rgba(117, 162, 235, 0.58) 38%, rgba(97, 208, 199, 0.24) 65%, transparent 100%);
   filter: blur(2.5px);
   animation: st-home-meteor-fly 0.95s cubic-bezier(0.22, 0.8, 0.18, 1) both;
   animation-play-state: paused;
@@ -1736,11 +2169,16 @@ html[data-theme='light'] .st-home {
 
 .st-home-rv {
   --rv-progress: 0;
-  opacity: calc(0.34 + (var(--rv-progress) * 0.66));
-  transform: translateY(calc((1 - var(--rv-progress)) * 18px));
-  filter: brightness(calc(0.84 + (var(--rv-progress) * 0.16)));
+  opacity: calc(0.62 + (var(--rv-progress) * 0.38));
+  transform: translateY(calc((1 - var(--rv-progress)) * 14px));
+  filter: brightness(calc(0.93 + (var(--rv-progress) * 0.07)));
   will-change: opacity, transform, filter;
   transition: opacity 0.32s ease, transform 0.32s ease, filter 0.32s ease, color 0.32s ease;
+}
+
+.st-home-architecture-board.st-home-rv {
+  transform: perspective(1600px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y))
+    translateY(calc(var(--lift-y) + ((1 - var(--rv-progress)) * 18px)));
 }
 
 .st-home-eyebrow.st-home-rv,
@@ -1782,6 +2220,168 @@ html[data-theme='light'] .st-home .st-home-flow-card {
   box-shadow: 0 18px 44px rgba(39, 63, 101, 0.1);
 }
 
+html[data-theme='light'] .st-home .st-home-architecture-board {
+  border-color: rgba(90, 150, 230, 0.14);
+  background:
+    radial-gradient(circle at 12% 18%, rgba(84, 196, 255, 0.12), transparent 28%),
+    radial-gradient(circle at 84% 18%, rgba(97, 208, 199, 0.1), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 248, 255, 0.92));
+  box-shadow:
+    0 32px 72px rgba(125, 154, 210, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board::before {
+  border-color: rgba(84, 164, 239, 0.12);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board::after {
+  opacity: 0.86;
+  background:
+    radial-gradient(circle at var(--spot-x) var(--spot-y), rgba(255, 255, 255, 0.48), transparent 24%),
+    linear-gradient(120deg, transparent 0%, rgba(103, 200, 193, 0.12) 46%, transparent 52%),
+    linear-gradient(180deg, transparent 0%, rgba(127, 163, 236, 0.03) 100%);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board.is-hovering {
+  border-color: rgba(87, 156, 236, 0.24);
+  box-shadow:
+    0 40px 88px rgba(96, 130, 196, 0.24),
+    0 18px 42px rgba(122, 164, 228, 0.18);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board.is-hovering::before {
+  border-color: rgba(95, 167, 243, 0.2);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-stage {
+  color: #5f79a2;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-stage-index {
+  background: rgba(91, 146, 231, 0.1);
+  color: #4d7fd7;
+  box-shadow:
+    inset 0 0 0 1px rgba(100, 154, 236, 0.12),
+    0 10px 24px rgba(136, 164, 214, 0.08);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-pipelines svg {
+  filter: drop-shadow(0 12px 28px rgba(94, 136, 219, 0.12));
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-pipe-base {
+  stroke: rgba(111, 170, 238, 0.24);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-pipe-core {
+  stroke: rgba(255, 255, 255, 0.92);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-pipe-edge {
+  stroke: rgba(104, 182, 255, 0.52);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board.is-hovering .st-home-architecture-pipelines svg {
+  filter: drop-shadow(0 16px 32px rgba(92, 140, 228, 0.18));
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-box {
+  border-color: rgba(105, 161, 235, 0.22);
+  background: linear-gradient(180deg, rgba(245, 249, 255, 0.92), rgba(229, 239, 255, 0.86));
+  box-shadow:
+    0 26px 54px rgba(116, 147, 206, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-box::before {
+  background:
+    radial-gradient(circle at var(--engine-spot-x) var(--engine-spot-y), rgba(255, 255, 255, 0.52), transparent 18%),
+    radial-gradient(circle at 20% 18%, rgba(66, 184, 236, 0.18), transparent 28%),
+    radial-gradient(circle at 80% 12%, rgba(97, 208, 199, 0.12), transparent 32%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.34), transparent 55%);
+  border-color: rgba(97, 152, 231, 0.16);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-box::after {
+  background: linear-gradient(90deg, transparent, rgba(84, 162, 235, 0.18), transparent);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine.is-hovering .st-home-architecture-engine-box {
+  border-color: rgba(91, 156, 236, 0.28);
+  box-shadow:
+    0 34px 68px rgba(100, 139, 207, 0.26),
+    0 0 0 1px rgba(96, 156, 235, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.76);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-logo {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(235, 242, 255, 0.84));
+  box-shadow:
+    0 18px 36px rgba(118, 147, 204, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  border-color: rgba(91, 155, 236, 0.18);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine.is-hovering .st-home-architecture-engine-logo {
+  box-shadow:
+    0 22px 44px rgba(118, 147, 204, 0.24),
+    0 0 28px rgba(111, 146, 255, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-name {
+  color: #183358;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-pillar {
+  background: rgba(255, 255, 255, 0.58);
+  border-color: rgba(98, 150, 230, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.62);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine.is-hovering .st-home-architecture-engine-pillar {
+  border-color: rgba(97, 152, 231, 0.2);
+  background: rgba(255, 255, 255, 0.68);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-pillar strong {
+  color: #28456c;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-engine-pillar span {
+  color: #55729c;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(242, 247, 255, 0.94));
+  border-color: rgba(94, 140, 210, 0.14);
+  box-shadow: 0 22px 44px rgba(119, 146, 198, 0.12);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-card:hover {
+  box-shadow: 0 30px 58px rgba(97, 131, 193, 0.2);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-card-dot {
+  box-shadow: 0 0 18px rgba(111, 146, 255, 0.3);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-card-head > span:nth-child(2) {
+  color: #3f5f89;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-card-tag {
+  color: #8ea5c4;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-chip {
+  border-color: rgba(96, 136, 198, 0.16);
+  background: linear-gradient(180deg, rgba(248, 251, 255, 0.98), rgba(242, 247, 255, 0.92));
+  color: #4e6d97;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
 html[data-theme='light'] .st-home .st-home-pipeline-visual {
   border-color: rgba(75, 95, 131, 0.22);
   background: linear-gradient(180deg, rgba(14, 22, 38, 0.96) 0%, rgba(9, 16, 30, 0.98) 100%);
@@ -1807,12 +2407,39 @@ html[data-theme='light'] .st-home .st-home-pipeline-visual .st-home-pipeline-cen
 }
 
 html[data-theme='light'] .st-home .st-home-connectors-section {
-  background: linear-gradient(180deg, #f5f8ff 0%, #edf3ff 100%);
+  background: linear-gradient(180deg, #f4f8fd 0%, #ecf2fa 100%);
+}
+
+html[data-theme='light'] .st-home .st-home-features-section {
+  background: linear-gradient(180deg, #eff5fb 0%, #e7eef8 100%);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture {
+  background: linear-gradient(180deg, #edf4fc 0%, #e6eef8 100%);
 }
 
 html[data-theme='light'] .st-home .st-home-stats,
 html[data-theme='light'] .st-home .st-home-stat {
   background: #eaf1fb;
+}
+
+html[data-theme='light'] .st-home .st-home-stats-band {
+  background: #eaf1fb;
+}
+
+html[data-theme='light'] .st-home .st-home-stats-shell {
+  border-color: rgba(90, 150, 230, 0.14);
+  background:
+    radial-gradient(circle at 12% 20%, rgba(84, 196, 255, 0.11), transparent 24%),
+    radial-gradient(circle at 86% 22%, rgba(97, 208, 199, 0.08), transparent 26%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(243, 248, 255, 0.94));
+  box-shadow:
+    0 24px 52px rgba(99, 129, 186, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+html[data-theme='light'] .st-home .st-home-stats-shell::after {
+  border-color: rgba(107, 149, 220, 0.08);
 }
 
 html[data-theme='light'] .st-home .st-home-hero-badge {
@@ -1860,11 +2487,36 @@ html[data-theme='light'] .st-home .st-home-cta-subtitle {
   color: #39526f;
 }
 
+html[data-theme='light'] .st-home .st-home-stat-label {
+  color: #5b7394;
+}
+
 html[data-theme='light'] .st-home .st-home-meta-tag,
 html[data-theme='light'] .st-home .st-home-architecture-chip,
 html[data-theme='light'] .st-home .st-home-flow-tag,
 html[data-theme='light'] .st-home .st-home-marquee-chip {
   color: #4e6886;
+}
+
+html[data-theme='light'] .st-home .st-home-feature-card {
+  border-color: rgba(33, 54, 88, 0.14);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 18px 38px rgba(58, 87, 132, 0.1);
+}
+
+html[data-theme='light'] .st-home .st-home-feature-card::before {
+  background: radial-gradient(240px circle at var(--mx, 50%) var(--my, 50%), rgba(93, 184, 226, 0.06), transparent 60%);
+}
+
+html[data-theme='light'] .st-home .st-home-feature-highlight {
+  border-color: rgba(104, 148, 220, 0.14);
+  background: rgba(235, 243, 253, 0.9);
+  color: #55729c;
+}
+
+html[data-theme='light'] .st-home .st-home-rv {
+  opacity: calc(0.78 + (var(--rv-progress) * 0.22));
+  filter: brightness(calc(0.98 + (var(--rv-progress) * 0.02)));
 }
 
 html[data-theme='light'] .st-home .st-home-feature-number,
@@ -1894,6 +2546,25 @@ html[data-theme='light'] .st-home .st-home-section-title.st-home-rv {
 
 html[data-theme='light'] .st-home .st-home-section-lead.st-home-rv {
   color: #314a67;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board {
+  border-color: rgba(90, 150, 230, 0.22);
+  background:
+    radial-gradient(circle at 14% 18%, rgba(84, 196, 255, 0.07), transparent 22%),
+    radial-gradient(circle at 84% 18%, rgba(97, 208, 199, 0.05), transparent 24%),
+    linear-gradient(180deg, rgba(251, 253, 255, 0.99), rgba(235, 242, 251, 0.99));
+  box-shadow:
+    0 24px 56px rgba(103, 134, 190, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-board::after {
+  opacity: 0.52;
+}
+
+html[data-theme='light'] .st-home .st-home-architecture-card {
+  box-shadow: 0 16px 34px rgba(103, 134, 190, 0.08);
 }
 
 html[data-theme='light'] .st-home .st-home-rv {
@@ -1930,9 +2601,40 @@ html[data-theme='light'] .st-home .st-home-rv {
     grid-template-columns: 1fr;
   }
 
-  .st-home-feature-card-wide {
+  .st-home-feature-card-wide,
+  .st-home-feature-card-span-2 {
     grid-column: span 1;
+  }
+
+  .st-home-feature-card-wide {
     grid-template-columns: 1fr;
+  }
+
+  .st-home-stats-band {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .st-home-stat {
+    padding: 1.25rem 1rem;
+  }
+
+  .st-home-stat + .st-home-stat::before {
+    display: none;
+  }
+
+  .st-home-architecture-board {
+    margin-top: 2.5rem;
+    padding: 1.375rem 0.875rem;
+    transform: none;
+  }
+
+  .st-home-architecture-board::before {
+    inset: 0.875rem;
+  }
+
+  .st-home-architecture-board-inner {
+    min-height: auto;
+    padding: 0;
   }
 
   .st-home-architecture-header {
@@ -1946,21 +2648,24 @@ html[data-theme='light'] .st-home .st-home-rv {
   }
 
   .st-home-architecture-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .st-home-architecture-grid > * {
-    grid-column: auto !important;
-    grid-row: auto !important;
+    grid-template-columns: 1fr;
+    min-height: auto;
   }
 
   .st-home-architecture-engine {
-    grid-column: 1 / 3 !important;
-    padding: 0.75rem 0;
     order: -1;
   }
 
-  .st-home-architecture-connector {
+  .st-home-architecture-column {
+    gap: 0.875rem;
+  }
+
+  .st-home-architecture-card,
+  .st-home-architecture-engine-box {
+    min-height: auto;
+  }
+
+  .st-home-architecture-pipelines {
     display: none;
   }
 
@@ -2008,11 +2713,6 @@ html[data-theme='light'] .st-home .st-home-rv {
   .st-home-architecture-grid {
     grid-template-columns: 1fr;
   }
-
-  .st-home-architecture-engine {
-    grid-column: auto !important;
-  }
-
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- reduce repeated homepage storytelling by keeping Architecture as the primary explainer, removing the extra hero pipeline visual, and dropping the repeated Flow section
- rebalance the Why SeaTunnel section with lighter CDC copy, clearer highlight pills, stronger CTA copy, and the requested cleanup of the architecture/CTA title divider lines plus the footer top divider
- tighten the mid-page light-mode section boundaries and restore the stats strip motion feel while slowing the moving stars down

## Validation
- `npm run start -- --host 127.0.0.1 --port 3042`
  - verified the homepage at `http://127.0.0.1:3042/`
  - confirmed the Architecture title and CTA title no longer render the meteor divider line
  - confirmed the footer no longer renders a top border line
- `npm run build`
  - observed final client and server compile success during the production build run

## Notes
- no reusable prebuilt modules or artifacts were relied on in this run
- the existing `seatunnel-workflow.svg` warnings under versioned docs and `static/image_en` are pre-existing and not introduced by this PR
