### PR TITLE
[Docs] Document how to become a collaborator

### DIFF
--- a/community/contribution_guide/contribute.md
+++ b/community/contribution_guide/contribute.md
@@ -122,6 +122,25 @@ When resolving ISSUEs, observe a few useful conventions:
 - Umbrellas are frequently marked **Done** if they are just container issues that don't correspond
   to an actionable change of their own
 
+## Becoming a collaborator
+
+Some active contributors may be invited to become GitHub collaborators for the main
+[`apache/seatunnel`](https://github.com/apache/seatunnel) repository. This is a lightweight
+triage role that helps the community keep issues and pull requests moving. Collaborators can
+help label issues, organize follow-up work, and route reviews, but the role does not grant ASF
+committer privileges.
+
+A contributor can ask about the role, or an existing committer or PPMC member can propose them
+after a sustained record of helpful community work. Useful signals include opening and improving
+PRs, reviewing changes, reproducing bugs, triaging issues, and helping users on the mailing list.
+
+To propose a new collaborator, open a PR against
+[`apache/seatunnel`](https://github.com/apache/seatunnel) that adds the contributor's GitHub
+username to the `github.collaborators` list in
+[`apache/seatunnel/.asf.yaml`](https://github.com/apache/seatunnel/blob/dev/.asf.yaml).
+Committers can review the contributor's past activity and approve the update. Collaborators who
+become inactive for a long period may be removed from the list.
+
 ## Preparing to contribute code changes
 
 ### Choosing what to contribute

--- a/community/contribution_guide/contribute.md
+++ b/community/contribution_guide/contribute.md
@@ -130,7 +130,7 @@ triage role that helps the community keep issues and pull requests moving. Colla
 help label issues, organize follow-up work, and route reviews, but the role does not grant ASF
 committer privileges.
 
-A contributor can ask about the role, or an existing committer or PPMC member can propose them
+A contributor can ask about the role, or an existing committer or PMC member can propose them
 after a sustained record of helpful community work. Useful signals include opening and improving
 PRs, reviewing changes, reproducing bugs, triaging issues, and helping users on the mailing list.
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/contribute.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/contribute.md
@@ -51,7 +51,7 @@ sidebar_position: 1
 issue 和 PR triage 的轻量角色，主要用于帮助社区维护 issue、补充标签、跟进后续处理和协助
 reviewer 路由；它不等同于 ASF Committer，也不代表已经获得代码合并或发布权限。
 
-贡献者可以主动向 Committer 或 PPMC 成员了解该角色，现有 Committer 或 PPMC 也可以基于持续
+贡献者可以主动向 Committer 或 PMC 成员了解该角色，现有 Committer 或 PMC 也可以基于持续
 贡献主动提名。通常会重点参考这些贡献记录：持续提交和改进 PR、参与 review、复现和澄清 bug、
 帮助整理 issue，以及在邮件列表中帮助用户。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/contribute.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/contribution_guide/contribute.md
@@ -43,3 +43,20 @@ sidebar_position: 1
 * 完成后，发送一个 Pull Request 到 Apache Seatunnel，提交过程具体请参考下面《[提交代码流程](submit_guide/document.md)》。
 
 如果是想提交 Pull Request 完成某一个 Feature 或者修复某个 Bug，这里都建议大家从小处做起，完成一个小功能就提交一次，每次别改动太多文件，改动文件太多也会给 Reviewer 造成很大的心理压力，建议通过多次 Pull Request 的方式完成。
+
+### 4. 如何成为 GitHub Collaborator（协作者）
+
+对于已经持续参与社区的贡献者，社区可能会邀请其成为主仓库
+[`apache/seatunnel`](https://github.com/apache/seatunnel) 的 GitHub Collaborator。这是一个偏向
+issue 和 PR triage 的轻量角色，主要用于帮助社区维护 issue、补充标签、跟进后续处理和协助
+reviewer 路由；它不等同于 ASF Committer，也不代表已经获得代码合并或发布权限。
+
+贡献者可以主动向 Committer 或 PPMC 成员了解该角色，现有 Committer 或 PPMC 也可以基于持续
+贡献主动提名。通常会重点参考这些贡献记录：持续提交和改进 PR、参与 review、复现和澄清 bug、
+帮助整理 issue，以及在邮件列表中帮助用户。
+
+如果要提名新的 Collaborator，可以向
+[`apache/seatunnel`](https://github.com/apache/seatunnel) 提交一个 PR，在
+[`apache/seatunnel/.asf.yaml`](https://github.com/apache/seatunnel/blob/dev/.asf.yaml) 的
+`github.collaborators` 列表中加入对应 GitHub 用户名。Committer 会根据候选人的历史贡献进行
+审阅并决定是否接受。若长期不活跃，社区也可能将其从协作者列表中移除。


### PR DESCRIPTION
## What changed
- add a new `Becoming a collaborator` section to the English community contribution guide
- add the matching `如何成为 GitHub Collaborator（协作者）` section to the Chinese community contribution guide
- explain that the collaborator role is a lightweight GitHub triage role for `apache/seatunnel`, not ASF committership, and that proposals are made through `github.collaborators` in `apache/seatunnel/.asf.yaml`

## Why
- SeaTunnel already maintains a real collaborator list in the main repository, but the contribution guide did not explain what the role is or how contributors can be proposed
- this adds the same kind of guidance that Apache Arrow documented in arrow#36445, but places it in SeaTunnel's contribution guide where contributors will actually look first

## Validation
- verified the English route in a focused local Docusaurus community-doc preview at `/community/contribution_guide/contribute`
- verified the Chinese route in a focused local Docusaurus zh-CN preview at `/zh-CN/community/contribution_guide/contribute`
- the current `main` full-site preview still has pre-existing missing `sidebars.js` / `docs` references and unrelated legacy content warnings, so validation was performed with a narrowed community-doc preview instead of the noisy full-site baseline
