### PR TITLE
[Docs] Rename navbar to Docs and clarify current doc ownership

### DIFF
--- a/HOW_DOC_WORK.md
+++ b/HOW_DOC_WORK.md
@@ -1,22 +1,26 @@
 # How Documentation Work
 
-[Our website](https://seatunnel.apache.org) is generated based on this repository(**apache/seatunnel-website**),
-but the content of document is hold on [our codebase repository](https://github.com/apache/seatunnel/tree/dev/docs).
-So we have to fetch the document from the codebase repository before we build the document.
+[Our website](https://seatunnel.apache.org) is generated from this repository (**apache/seatunnel-website**),
+but the current documentation content is sourced from [our codebase repository](https://github.com/apache/seatunnel/tree/dev/docs).
+That means we have to fetch the docs from the codebase repository before we build the site.
 
-Indeed, you could fetch it by your hand, but we provide the more convenience way to do it, the `build-docs.sh` in directory
-`tools`. It will
+In practice, the repository boundary is:
+
+- Edit **current docs pages** in `apache/seatunnel` under `docs/en` and `docs/zh`.
+- Edit the **website shell** in `apache/seatunnel-website`, including the homepage, navigation, version entry, search, styles, rendering, community pages, and historical version snapshots.
+
+You could fetch the docs manually, but we provide a more convenient script: `tools/build-docs.sh`. It will:
 
 * Create the directory named `swap` under your project directory, as well `docs` and `static/image_en`.
 * Fetch the latest code in codebase repository(apache/seatunnel) to directory `swap`.
 * Sync the latest `seatunnel/docs/en` and `seatunnel/docs/en/image` to directory `docs` and `static/image_en`.
 
-When the main library code is synchronized to the local, HTTP is used by default as the protocol for git to communicate with the server, because it do not requests password or secret key. such as local development where we already have RSA public key, run command `export PROTOCOL_MODE=ssh` in terminal change protocol to SSH which in is faster and stable in many cases.
+When the main library code is synchronized locally, HTTP is used by default because it does not require a password or secret key.
+If you already use SSH locally, run `export PROTOCOL_MODE=ssh` in your terminal to switch the fetch protocol.
 
-After that, you are finish the prepare work, and all resources you need to build our website it there, you could run your
-`npm` command to build the website.
+After that, the site has the resources it needs and you can run the normal `npm` commands to build or preview it.
 
 ## How It Works in GitHub Action
 
-Our GitHub Action also use script `tools/build-docs.sh` to finish its prepare work. Consistent way to prepare and build
-the website is good for both development and production maintenance.
+Our GitHub Action also uses `tools/build-docs.sh` for the prepare step.
+Using the same sync path in local development and CI keeps website maintenance predictable.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 This is the repository containing all the source code of `https://seatunnel.apache.org`.
 This guide will guide you how to contribute to the SeaTunnel website.
 
+## Repository boundary
+
+`apache/seatunnel-website` is the website shell repository.
+
+- Edit **current docs content** in `apache/seatunnel` under `docs/en` and `docs/zh`.
+- Edit **website shell concerns** in `apache/seatunnel-website`, such as the homepage, navigation, version entry, search, styles, rendering, community pages, and versioned docs snapshots.
+
+If you are changing a page under `/docs` for the current unreleased docs, the source of truth is `apache/seatunnel`, not this repository.
+
 ## Branch
 
 main is the default branch. For all modifications, please fork first, and then proceed on the main branch.
@@ -23,7 +32,7 @@ This website is compiled using node, using Docusaurus framework components
 
 1. Download and install nodejs (version>14)
 2. Clone the code to the local `git clone git@github.com:apache/seatunnel-website.git`
-3. Run `./tools/build-docs.sh` to fetch and prepare docs form **apache/seatunnel**, for more information you could see [how our document work](HOW_DOC_WORK.md)
+3. Run `./tools/build-docs.sh` to fetch and prepare current docs from **apache/seatunnel**. For more details, see [how our docs work](HOW_DOC_WORK.md)
 4. Run `npm install` to install the required dependent libraries.
 5. Run `npm run start` in the root directory, you can visit http://localhost:3000 to view the English mode preview of the site
 6. Run `npm run start-zh` in the root directory, you can visit http://localhost:3000 to view the Chinese mode preview of the site

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,6 +7,15 @@
 这是包含 `https://seatunnel.apache.org` 的所有源代码的存储库。
 本指南将指导您如何为SeaTunnel的网站做出贡献。
 
+## 仓库边界
+
+`apache/seatunnel-website` 是网站壳仓库。
+
+- **当前版本文档内容** 请在 `apache/seatunnel` 的 `docs/en` 和 `docs/zh` 中修改。
+- **网站壳能力** 请在 `apache/seatunnel-website` 中修改，例如首页、导航、版本入口、搜索、样式、渲染、社区页面，以及历史版本文档快照。
+
+如果您修改的是网站 `/docs` 下的当前未发布文档页面，source of truth 在 `apache/seatunnel`，不在本仓库。
+
 ## 分支
 
 main为默认主分支，修改请先fork到自己的仓库，然后在main分支上进行开发修改。
@@ -23,7 +32,7 @@ asf-staging 官网测试环境  通过https://seatunnel.staged.apache.org 访问
 
 1. 下载并安装 nodejs(version>14)
 2. 克隆代码到本地 `git clone  git@github.com:apache/seatunnel-website.git`
-3. 运行 `./tools/build-docs.sh` 从 **apache/seatunnel** 中拉取、准备文档。如果想要了解更多细节和操作请阅读[文档如何工作](HOW_DOC_WORK.md)
+3. 运行 `./tools/build-docs.sh` 从 **apache/seatunnel** 中拉取并准备当前文档。如果想了解更多细节，请阅读[文档如何工作](HOW_DOC_WORK.md)
 4. 运行 `npm install` 来安装所需的依赖库。
 5. 在根目录运行`npm run start`，可以访问http://localhost:3000查看站点英文模式预览
 6. 在根目录运行`npm run start-zh`，可以访问http://localhost:3000查看站点的中文模式预览

--- a/community/submit_guide/document.md
+++ b/community/submit_guide/document.md
@@ -7,15 +7,25 @@ sidebar_position: 1
 
 Good documentation is critical for any type of software. Any contribution that can improve the Seatunnel documentation is welcome.
 
-##  Get the document project
+## Choose the right repository
 
-Documentation for the Seatunnel project is maintained in a separate [git repository](https://github.com/apache/seatunnel-website).
+SeaTunnel documentation work now spans two repositories:
 
-First you need to fork the document project into your own github repository, and then clone the document to your local computer.
+- **Current docs pages** under `https://seatunnel.apache.org/docs/...` are sourced from [apache/seatunnel](https://github.com/apache/seatunnel/tree/dev/docs).
+- **Website shell pages** are maintained in [apache/seatunnel-website](https://github.com/apache/seatunnel-website), including the homepage, navigation, version entry, search, styles, rendering, community pages, and versioned docs snapshots.
+
+If you are editing a current docs page, open your PR in `apache/seatunnel`.
+If you are editing the website shell or a historical/versioned snapshot, open your PR in `apache/seatunnel-website`.
+
+## Get the website project
+
+If your change belongs in `apache/seatunnel-website`, fork the website repository into your own GitHub account and then clone it locally.
 
 ```shell
 git clone https://github.com/<your-github-user-name>/seatunnel-website
 ```
+
+If your change belongs in `apache/seatunnel`, follow the docs build and contribution instructions in that repository instead.
 
 ## Preview and generate static files
 
@@ -88,7 +98,7 @@ Image resources are unified under `static/{module name}`
 css and other style files are placed in the `src/css` directory
 
 ### Page content modification
-> Except for the homepage, team, user, Docs>All Version module page, all other pages can be directly jumped to the corresponding github resource modification page through the'Edit this page' button at the bottom
+> Current docs pages use the bottom `Edit this page` button to route contributors to `apache/seatunnel`. Homepage, team, user, versions, and other website shell pages continue to route to `apache/seatunnel-website`.
 
 ### Home page modification
 Visit the page https://seatunnel.apache.org

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,6 +80,15 @@ function getZhBlogExcludePatterns() {
   return exclude;
 }
 
+function getDocsEditUrl({ version, versionDocsDirPath, docPath, locale }) {
+  if (version === "current") {
+    const sourceLocaleDir = locale === "zh-CN" ? "zh" : "en";
+    return `https://github.com/apache/seatunnel/edit/dev/docs/${sourceLocaleDir}/${docPath}`;
+  }
+
+  return `https://github.com/apache/seatunnel-website/edit/main/${versionDocsDirPath}/${docPath}`;
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   markdown: {
@@ -168,9 +177,8 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsible: true,
           editLocalizedFiles: true,
-          // Please change this to your repo.
-          editUrl:
-            "https://github.com/apache/seatunnel-website/edit/main/",
+          // Current docs are sourced from apache/seatunnel, while historical snapshots stay in this repo.
+          editUrl: getDocsEditUrl,
           versions: {
             current: {
               path: "",
@@ -240,7 +248,7 @@ const config = {
       items: [
         {
           position: "right",
-          label: "Document",
+          label: "Docs",
           items: [
             ...versions.slice(0, 5).map((version) => ({
               label: version,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/submit_guide/document.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/submit_guide/document.md
@@ -7,15 +7,25 @@ sidebar_position: 1
 
 良好的使用文档对任何类型的软件都是至关重要的。欢迎任何可以改进 Seatunnel 文档的贡献。
 
-## 获取文档项目
+## 先确认该改哪个仓库
 
-Seatunnel 项目的文档维护在独立的 [git 仓库] (https://github.com/apache/seatunnel-website) 中。
+SeaTunnel 的文档工作现在分布在两个仓库中：
 
-首先你需要先将文档项目 fork 到自己的 github 仓库中，然后将 fork 的文档克隆到本地计算机中。
+- **当前版本文档页面**，也就是 `https://seatunnel.apache.org/docs/...` 下的页面，source of truth 在 [apache/seatunnel](https://github.com/apache/seatunnel/tree/dev/docs)。
+- **网站壳页面** 在 [apache/seatunnel-website](https://github.com/apache/seatunnel-website) 中维护，例如首页、导航、版本入口、搜索、样式、渲染、社区页面，以及历史版本文档快照。
+
+如果您修改的是当前版本文档页面，请到 `apache/seatunnel` 提 PR。
+如果您修改的是网站壳或历史版本快照，请到 `apache/seatunnel-website` 提 PR。
+
+## 获取网站项目
+
+如果您的改动属于 `apache/seatunnel-website`，请先 fork 该仓库，再克隆到本地：
 
 ```
 git clone https://github.com/<your-github-user-name>/seatunnel-website
 ```
+
+如果您的改动属于 `apache/seatunnel`，请改为参考主仓库中的文档构建与提交流程。
 
 ## 预览并生成静态文件
 
@@ -88,7 +98,7 @@ git clone https://github.com/<your-github-user-name>/seatunnel-website
 css等样式文件放在`src/css`目录下
 
 ### 页面内容修改
-> 除了首页、团队、用户、Docs>All Version 模块页面外，其余页面都能通过底部的'Edit this page'按钮 直接跳转至对应的github的资源修改页
+> 当前版本文档页面底部的 `Edit this page` 会把贡献者导向 `apache/seatunnel`。首页、团队、用户、版本列表等网站壳页面仍然会导向 `apache/seatunnel-website`。
 
 ### 首页页面修改
 访问页面  https://seatunnel.apache.org/


### PR DESCRIPTION
## What changed

- rename the navbar entry from `Document` to `Docs`
- route current docs `Edit this page` links to `apache/seatunnel`, while keeping versioned snapshots in `apache/seatunnel-website`
- document the repository boundary in the website contribution guides and READMEs so contributors know where current docs content vs website shell changes belong

## Why

Current docs content now lives in `apache/seatunnel`, while `apache/seatunnel-website` owns the website shell such as navigation, version entry, search, styles, rendering, community pages, and versioned snapshots.
Without that boundary, contributors can still edit content in one place while the site entry points keep sending them to the wrong repository.

## Validation

- verified the navbar config resolves `Docs`
- verified `editUrl` resolves current EN/ZH docs to `apache/seatunnel` and versioned docs to `apache/seatunnel-website`
- attempted local `npm run build`, but the current local dependency tree is corrupted and fails before site rendering with `Cannot find module '.../node_modules/detect-port/node_modules/debug/src/index.js'`
