### PR TITLE
[Fix][CI] Declare Docusaurus redirects plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^2.4.3",
+        "@docusaurus/plugin-client-redirects": "^2.4.3",
         "@docusaurus/plugin-content-docs": "^2.4.3",
         "@docusaurus/preset-classic": "^2.4.3",
         "@docusaurus/theme-mermaid": "^2.4.3",
@@ -2260,6 +2261,44 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmmirror.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.3.tgz",
+      "integrity": "sha512-iCwc/zH8X6eNtLYdyUJFY6+GbsbRgMgvAC/TmSmCYTmwnoN5Y1Bc5OwUkdtoch0XKizotJMRAmGIAhP8sAetdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
+        "eta": "^2.0.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.3",
+    "@docusaurus/plugin-client-redirects": "^2.4.3",
     "@docusaurus/plugin-content-docs": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",
     "@docusaurus/theme-mermaid": "^2.4.3",


### PR DESCRIPTION
## What does this PR do?

Declare the missing `@docusaurus/plugin-client-redirects` dependency that is already referenced by `docusaurus.config.js`.

This is the shared root cause behind the `Build website` failure currently blocking multiple `apache/seatunnel` PRs, where the workflow checks out `apache/seatunnel-website`, runs `npm install`, and then fails during `npm run build` because the redirect plugin cannot be resolved.

## Why is the change needed?

`docusaurus.config.js` already registers `@docusaurus/plugin-client-redirects`, but `package.json` does not declare it. That makes local environments with leftover installs look fine while clean CI environments fail deterministically.

## How was it verified?

- Ran `npm set strict-ssl false`
- Ran `npm install`
- Ran `npm run sync`
- Ran `npm run build`
  - The original blocker `Docusaurus was unable to resolve the "@docusaurus/plugin-client-redirects" plugin` no longer occurs.
  - The build proceeds into full Docusaurus compilation; remaining console output is historical image warnings unrelated to this dependency fix.

## Additional note

This PR is intended as a shared CI fix to unblock `apache/seatunnel` PRs such as `#11231`, `#11250`, and `#11264`.
