### PR TITLE
Fix Docusaurus client redirects dependency

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,6 +80,20 @@ function getZhBlogExcludePatterns() {
   return exclude;
 }
 
+const userCaseRedirects = {
+  "/blog": ["/user_cases"],
+  "/blog/tags": ["/user_cases/tags"],
+  "/blog/The-practice-of-SeaTunnel-in-Vip": [
+    "/user_cases/The-practice-of-SeaTunnel-in-Vip",
+  ],
+  "/blog/SeaTunnel 在唯品会的实践": [
+    "/user_cases/The-practice-of-SeaTunnel-in-Vip",
+  ],
+  "/blog/tags/vip": ["/user_cases/tags/vip"],
+  "/blog/tags/唯品会": ["/user_cases/tags/vip"],
+  "/blog/tags/click-house": ["/user_cases/tags/click-house"],
+};
+
 function getDocsEditUrl({ version, versionDocsDirPath, docPath, locale }) {
   if (version === "current") {
     const sourceLocaleDir = locale === "zh-CN" ? "zh" : "en";
@@ -447,28 +461,9 @@ const config = {
     [
       "@docusaurus/plugin-client-redirects",
       {
-        redirects: [
-          {
-            from: "/user_cases",
-            to: "/blog",
-          },
-          {
-            from: "/user_cases/tags",
-            to: "/blog/tags",
-          },
-          {
-            from: "/user_cases/The-practice-of-SeaTunnel-in-Vip",
-            to: "/blog/The-practice-of-SeaTunnel-in-Vip",
-          },
-          {
-            from: "/user_cases/tags/vip",
-            to: "/blog/tags/vip",
-          },
-          {
-            from: "/user_cases/tags/click-house",
-            to: "/blog/tags/click-house",
-          },
-        ],
+        createRedirects(existingPath) {
+          return userCaseRedirects[existingPath] || [];
+        },
       },
     ],
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^2.4.3",
+        "@docusaurus/plugin-client-redirects": "^2.4.3",
         "@docusaurus/plugin-content-docs": "^2.4.3",
         "@docusaurus/preset-classic": "^2.4.3",
         "@docusaurus/theme-mermaid": "^2.4.3",
@@ -2260,6 +2261,44 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmmirror.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.3.tgz",
+      "integrity": "sha512-iCwc/zH8X6eNtLYdyUJFY6+GbsbRgMgvAC/TmSmCYTmwnoN5Y1Bc5OwUkdtoch0XKizotJMRAmGIAhP8sAetdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
+        "eta": "^2.0.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.3",
+    "@docusaurus/plugin-client-redirects": "^2.4.3",
     "@docusaurus/plugin-content-docs": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",
     "@docusaurus/theme-mermaid": "^2.4.3",


### PR DESCRIPTION
## Purpose

Fix the website build failure triggered by SeaTunnel docs PR checks. The site config already uses `@docusaurus/plugin-client-redirects`, but the package was missing from `package.json` and `package-lock.json`.

## Changes

- Add `@docusaurus/plugin-client-redirects` at the existing Docusaurus 2.4.3 version.
- Generate user case redirects only for paths that exist in the current locale, so the zh-CN build does not fail on English-only blog paths.

## Verification

- `npm ci`
- Synced docs from apache/seatunnel#11263 with `tools/documents/sync.sh`
- `npm run build`