### PR TITLE
[Docs] Add zh-CN translation for Scenario Recipes sidebar

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -95,6 +95,10 @@
     "message": "通用参数",
     "description": "The label for category Common Options in sidebar docs"
   },
+  "sidebar.docs.category.Scenario Recipes": {
+    "message": "场景教程",
+    "description": "The label for category Scenario Recipes in sidebar docs"
+  },
   "sidebar.docs.category.Changelog": {
     "message": "更新记录",
     "description": "The label for category Changelog in sidebar docs"


### PR DESCRIPTION
## Summary
- add the missing zh-CN translation for the `Scenario Recipes` sidebar category as `场景教程`
- keep the current docs sidebar aligned with the paired source-doc rename in https://github.com/apache/seatunnel/pull/11391

## Verification
- `npm install`
- sync the current docs and `sidebars.js` into a temporary website copy with `tools/documents/sync.sh`
- `npm run build` in that synced temporary copy