### PR TITLE
[Docs] Update 2.3.13 JVM heap recommendations

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/engines/zeta/separated-cluster-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/engines/zeta/separated-cluster-deployment.md
@@ -29,8 +29,8 @@ Master节点的JVM参数在`$SEATUNNEL_HOME/config/jvm_master_options`文件中�
 
 ```shell
 # JVM Heap
--Xms2g
--Xmx2g
+-Xms16g
+-Xmx16g
 
 # JVM Dump
 -XX:+HeapDumpOnOutOfMemoryError
@@ -48,8 +48,8 @@ Worker节点的JVM参数在`$SEATUNNEL_HOME/config/jvm_worker_options`文件中�
 
 ```shell
 # JVM Heap
--Xms2g
--Xmx2g
+-Xms16g
+-Xmx16g
 
 # JVM Dump
 -XX:+HeapDumpOnOutOfMemoryError
@@ -62,6 +62,8 @@ Worker节点的JVM参数在`$SEATUNNEL_HOME/config/jvm_worker_options`文件中�
 -XX:+UseG1GC
 
 ```
+
+以上示例使用 16 GB JVM 堆内存。对于大规模数据处理场景，建议使用 32 GB JVM 堆内存。
 
 ## 4. 配置 SeaTunnel Engine
 

--- a/versioned_docs/version-2.3.13/engines/zeta/separated-cluster-deployment.md
+++ b/versioned_docs/version-2.3.13/engines/zeta/separated-cluster-deployment.md
@@ -29,8 +29,8 @@ The JVM parameters of the Master node are configured in the `$SEATUNNEL_HOME/con
 
 ```shell
 # JVM Heap
--Xms2g
--Xmx2g
+-Xms16g
+-Xmx16g
 
 # JVM Dump
 -XX:+HeapDumpOnOutOfMemoryError
@@ -47,8 +47,8 @@ The JVM parameters of the Worker node are configured in the `$SEATUNNEL_HOME/con
 
 ```shell
 # JVM Heap
--Xms2g
--Xmx2g
+-Xms16g
+-Xmx16g
 
 # JVM Dump
 -XX:+HeapDumpOnOutOfMemoryError
@@ -60,6 +60,8 @@ The JVM parameters of the Worker node are configured in the `$SEATUNNEL_HOME/con
 # G1GC
 -XX:+UseG1GC
 ```
+
+The examples above use a 16 GB JVM heap. For large-scale data processing, a 32 GB JVM heap is recommended.
 
 ## 4. Configure SeaTunnel Engine
 


### PR DESCRIPTION
## What changed

- Updated the SeaTunnel 2.3.13 separated cluster deployment examples for both Master and Worker nodes from a 2 GB JVM heap to a 16 GB JVM heap.
- Updated the 2.3.13 Kubernetes Zeta cluster example to use a 16 GB heap, a 20 GiB memory request, and a 24 GiB memory limit.
- Corrected the Kubernetes shell quoting so both `-Xms` and `-Xmx` are passed through one `JvmOption` argument.
- Added a 32 GB JVM heap recommendation for large-scale data processing, with example Kubernetes request/limit values of 36 GiB and 40 GiB.
- Kept the English and Chinese versioned documentation consistent.

## Why

The 2.3.13 versioned documentation should provide the same practical JVM heap sizing guidance as the current SeaTunnel documentation, including runnable Kubernetes examples.

## User impact

Users reading the 2.3.13 deployment and Kubernetes guides will see updated heap sizing examples and the large-scale workload recommendation. This documentation-only change does not alter runtime defaults.

## Validation

- `git diff --check`
- Parsed the affected Kubernetes YAML examples.
- Verified matching `-Xms16g` and `-Xmx16g` values in both Master and Worker examples.
- Verified the Kubernetes command passes both heap options through one `JvmOption` argument.
- Verified the English and Chinese documents contain the same 32 GB recommendation.
- Verified Markdown/MDX code fences remain balanced.
