### PR TITLE
[Docs] Update 2.3.13 Kubernetes JVM heap guidance

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
@@ -529,14 +529,17 @@ spec:
           ports:
             - containerPort: 5801
               name: client
-          command: ["/bin/sh","-c","/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption=-Xms2G -Xmx2G"]
+          command:
+            - /bin/sh
+            - -c
+            - '/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption="-Xms16G -Xmx16G"'
           resources:
             limits:
               cpu: "1"
-              memory: 4G
+              memory: 24Gi
             requests:
               cpu: "1"
-              memory: 2G
+              memory: 20Gi
           volumeMounts:
             - mountPath: "/opt/seatunnel/config/hazelcast.yaml"
               name: hazelcast
@@ -576,6 +579,8 @@ spec:
             - key: seatunnel.streaming.conf
               path: seatunnel.streaming.conf
 ```
+
+此 Zeta 集群示例使用 16 GB JVM 堆内存。容器内存 request 设置为 20 GiB、limit 设置为 24 GiB，为 Metaspace、直接内存、线程栈和其他本地内存预留额外空间。对于大规模数据处理场景，建议使用 32 GB JVM 堆内存，并相应提高内存 request 和 limit，例如分别设置为 36 GiB 和 40 GiB。
 
 - 运行示例应用：
 ```bash

--- a/versioned_docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
+++ b/versioned_docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
@@ -529,14 +529,17 @@ spec:
           ports:
             - containerPort: 5801
               name: client
-          command: ["/bin/sh","-c","/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption=-Xms2G -Xmx2G"]
+          command:
+            - /bin/sh
+            - -c
+            - '/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption="-Xms16G -Xmx16G"'
           resources:
             limits:
               cpu: "1"
-              memory: 4G
+              memory: 24Gi
             requests:
               cpu: "1"
-              memory: 2G
+              memory: 20Gi
           volumeMounts:
             - mountPath: "/opt/seatunnel/config/hazelcast.yaml"
               name: hazelcast
@@ -567,6 +570,8 @@ spec:
             - key: seatunnel.streaming.conf
               path: seatunnel.streaming.conf
 ```
+
+This Zeta cluster example uses a 16 GB JVM heap. Its 20 GiB memory request and 24 GiB memory limit leave additional container memory for metaspace, direct memory, thread stacks, and other native memory. For large-scale data processing, a 32 GB JVM heap is recommended; increase the memory request and limit accordingly, for example to 36 GiB and 40 GiB.
 
 - Starting a cluster:
 ```bash


### PR DESCRIPTION
## What changed

- Updated the SeaTunnel 2.3.13 separated cluster deployment examples for both Master and Worker nodes from a 2 GB JVM heap to a 16 GB JVM heap.
- Updated the 2.3.13 Kubernetes Zeta cluster example to use a 16 GB heap, a 20 GiB memory request, and a 24 GiB memory limit.
- Corrected the Kubernetes shell quoting so both `-Xms` and `-Xmx` are passed through one `JvmOption` argument.
- Added a 32 GB JVM heap recommendation for large-scale data processing, with example Kubernetes request/limit values of 36 GiB and 40 GiB.
- Kept the English and Chinese versioned documentation consistent.

## Why

The 2.3.13 versioned documentation should provide the same practical JVM heap sizing guidance as the current SeaTunnel documentation, including runnable Kubernetes examples.

## User impact

Users reading the 2.3.13 deployment and Kubernetes guides will see updated heap sizing examples and the large-scale workload recommendation. This documentation-only change does not alter runtime defaults.

## Validation

- `git diff --check`
- Parsed the affected Kubernetes YAML examples.
- Verified matching `-Xms16g` and `-Xmx16g` values in both Master and Worker examples.
- Verified the Kubernetes command passes both heap options through one `JvmOption` argument.
- Verified the English and Chinese documents contain the same 32 GB recommendation.
- Verified Markdown/MDX code fences remain balanced.
