### PR TITLE
[Docs] Add 2.3.13 Kubernetes CPU sizing guidance

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
@@ -535,10 +535,10 @@ spec:
             - '/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption="-Xms16G -Xmx16G"'
           resources:
             limits:
-              cpu: "1"
+              cpu: "8"
               memory: 24Gi
             requests:
-              cpu: "1"
+              cpu: "4"
               memory: 20Gi
           volumeMounts:
             - mountPath: "/opt/seatunnel/config/hazelcast.yaml"
@@ -580,7 +580,7 @@ spec:
               path: seatunnel.streaming.conf
 ```
 
-此 Zeta 集群示例使用 16 GB JVM 堆内存。容器内存 request 设置为 20 GiB、limit 设置为 24 GiB，为 Metaspace、直接内存、线程栈和其他本地内存预留额外空间。对于大规模数据处理场景，建议使用 32 GB JVM 堆内存，并相应提高内存 request 和 limit，例如分别设置为 36 GiB 和 40 GiB。
+此 Zeta 集群示例使用 16 GB JVM 堆内存，CPU request 设置为 4、limit 设置为 8，容器内存 request 设置为 20 GiB、limit 设置为 24 GiB。内存余量用于 Metaspace、直接内存、线程栈和其他本地内存，CPU 配额用于任务执行、垃圾回收和引擎协调。对于大规模数据处理场景，建议使用 32 GB JVM 堆内存，可将 CPU request 和 limit 分别提高到 8 和 16，并将内存 request 和 limit 分别提高到 36 GiB 和 40 GiB，作为初始配置。请根据 Connector 特性、任务并行度以及实际 CPU、GC 和内存利用率继续调整。
 
 - 运行示例应用：
 ```bash

--- a/versioned_docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
+++ b/versioned_docs/version-2.3.13/getting-started/kubernetes/kubernetes.mdx
@@ -535,10 +535,10 @@ spec:
             - '/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption="-Xms16G -Xmx16G"'
           resources:
             limits:
-              cpu: "1"
+              cpu: "8"
               memory: 24Gi
             requests:
-              cpu: "1"
+              cpu: "4"
               memory: 20Gi
           volumeMounts:
             - mountPath: "/opt/seatunnel/config/hazelcast.yaml"
@@ -571,7 +571,7 @@ spec:
               path: seatunnel.streaming.conf
 ```
 
-This Zeta cluster example uses a 16 GB JVM heap. Its 20 GiB memory request and 24 GiB memory limit leave additional container memory for metaspace, direct memory, thread stacks, and other native memory. For large-scale data processing, a 32 GB JVM heap is recommended; increase the memory request and limit accordingly, for example to 36 GiB and 40 GiB.
+This Zeta cluster example uses a 16 GB JVM heap, requests 4 CPUs and 20 GiB of memory, and limits the container to 8 CPUs and 24 GiB of memory. The memory headroom is reserved for metaspace, direct memory, thread stacks, and other native memory, while the CPU allocation provides capacity for task execution, garbage collection, and engine coordination. For large-scale data processing, a 32 GB JVM heap is recommended; increase the CPU request and limit to 8 and 16, and the memory request and limit to 36 GiB and 40 GiB as a starting point. Adjust these values based on connector characteristics, job parallelism, and observed CPU, GC, and memory utilization.
 
 - Starting a cluster:
 ```bash


### PR DESCRIPTION
## What changed

- Updated the SeaTunnel 2.3.13 Kubernetes Zeta cluster example from a one-CPU container to:
  - CPU request: 4
  - CPU limit: 8
- Added a large-scale starting point for a 32 GB JVM heap:
  - CPU request: 8
  - CPU limit: 16
  - Memory request/limit: 36 GiB/40 GiB
- Kept the English and Chinese versioned documentation consistent.

## Why

The previous one-CPU limit was unbalanced with the documented 16 GB JVM heap. Task execution, garbage collection, Hazelcast, and engine coordination threads would compete for one CPU, causing throttling and avoidable throughput or latency instability.

## User impact

Users reading the 2.3.13 Kubernetes guide receive a practical CPU and memory starting point. The guide also states that production values should be adjusted using connector characteristics, job parallelism, and observed CPU, GC, and memory utilization.

This documentation-only change does not alter runtime or Helm chart defaults.

## Validation

- `git diff --check`
- Parsed all YAML blocks in both affected MDX documents.
- Verified matching CPU request/limit values of 4/8 in English and Chinese.
- Verified matching large-scale CPU and memory guidance of 8/16 and 36/40 GiB.
- Verified Markdown/MDX code fences remain balanced.
