### PR TITLE
Clarify 2.3.13 local deployment source build guidance

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/locally/deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.3.13/getting-started/locally/deployment.md
@@ -58,26 +58,11 @@ connector-console
 
 :::
 
-## 从源码构建SeaTunnel
+:::note 开发者说明
 
-### 下载源码
+本地部署指南默认面向使用 SeaTunnel 2.3.13 官方二进制发行包的用户。如果您需要验证源码变更、调试 SeaTunnel 源码，或构建自定义发行包，请参考[搭建开发环境](../../developer/setup.md)。
 
-从源码构建SeaTunnel。下载源码的方式与下载二进制包的方式相同。
-您可以从[下载页面](https://seatunnel.apache.org/download/)下载源码，或者从[GitHub仓库](https://github.com/apache/seatunnel/releases)克隆源码。
-
-### 构建源码
-
-```shell
-cd seatunnel
-sh ./mvnw clean install -DskipTests -Dskip.spotless=true
-# 获取构建好的二进制包
-cp seatunnel-dist/target/apache-seatunnel-2.3.13-bin.tar.gz /The-Path-You-Want-To-Copy
-
-cd /The-Path-You-Want-To-Copy
-tar -xzvf "apache-seatunnel-${version}-bin.tar.gz"
-```
-
-当从源码构建时，所有的连接器插件和一些必要的依赖（例如：mysql驱动）都包含在二进制包中。您可以直接使用连接器插件，而无需单独安装它们。
+:::
 
 # 启动SeaTunnel
 

--- a/versioned_docs/version-2.3.13/getting-started/locally/deployment.md
+++ b/versioned_docs/version-2.3.13/getting-started/locally/deployment.md
@@ -58,26 +58,11 @@ If you want to install connector plugins by manually downloading connectors, you
 
 :::
 
-## Build SeaTunnel From Source Code
+:::note Developer note
 
-### Download The Source Code
+This local deployment guide assumes that you use the official SeaTunnel 2.3.13 binary release package. If you need to validate source changes, debug SeaTunnel source code, or prepare a custom distribution, see [Set Up Develop Environment](../../developer/setup.md).
 
-Build from source code. The way of downloading the source code is the same as the way of downloading the binary package.
-You can download the source code from the [download page](https://seatunnel.apache.org/download/) or clone the source code from the [GitHub repository](https://github.com/apache/seatunnel/releases)
-
-### Build The Source Code
-
-```shell
-cd seatunnel
-sh ./mvnw clean install -DskipTests -Dskip.spotless=true
-# get the binary package
-cp seatunnel-dist/target/apache-seatunnel-2.3.13-bin.tar.gz /The-Path-You-Want-To-Copy
-
-cd /The-Path-You-Want-To-Copy
-tar -xzvf "apache-seatunnel-${version}-bin.tar.gz"
-```
-
-When built from the source code, all the connector plugins and some necessary dependencies (eg: mysql driver) are included in the binary package. You can directly use the connector plugins without the need to install them separately.
+:::
 
 # Run SeaTunnel
 


### PR DESCRIPTION
## Summary
- update the 2.3.13 versioned local deployment docs in English and zh-CN
- remove the source-build walkthrough from the deployment main flow
- replace it with a developer note linking to the 2.3.13 development environment guide

## Tests
- verified the 2.3.13 deployment pages no longer contain the source-build section or package-copy commands
- verified the linked 2.3.13 developer setup pages exist

Note: this PR targets apache/seatunnel-website:main because 2.3.13 is a Docusaurus docs version, not a Git branch.