### PR TITLE
[Docs] Add release notes link to the 2.3.13 download entry

### DIFF
--- a/src/pages/download/index.jsx
+++ b/src/pages/download/index.jsx
@@ -25,6 +25,7 @@ export default function () {
                             <th>Version</th>
                             <th>Binary Distribution</th>
                             <th>Source Code</th>
+                            <th>Release Notes</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -45,6 +46,9 @@ export default function () {
                                             <a href={st_item.sourceCode.asc}>[asc] {getLastPath(st_item.sourceCode.asc)}</a>
                                             <hr/>
                                             <a href={st_item.sourceCode.sha512}>[sha512] {getLastPath(st_item.sourceCode.sha512)}</a>
+                                        </td>
+                                        <td>
+                                            {st_item.releaseNotes ? <a href={st_item.releaseNotes}>Release Notes</a> : '-'}
                                         </td>
                                     </tr>
                                 )

--- a/src/pages/download/st_data.json
+++ b/src/pages/download/st_data.json
@@ -2,6 +2,7 @@
 	{
 		"date": "2026-03-12",
 		"version": "v2.3.13",
+		"releaseNotes": "https://github.com/apache/seatunnel/releases/tag/2.3.13",
 		"sourceCode": {
 			"src": "https://www.apache.org/dyn/closer.lua/seatunnel/2.3.13/apache-seatunnel-2.3.13-src.tar.gz",
 			"asc": "https://downloads.apache.org/seatunnel/2.3.13/apache-seatunnel-2.3.13-src.tar.gz.asc",


### PR DESCRIPTION
## What changed

The [Download page](https://seatunnel.apache.org/download) lists every SeaTunnel release with binary/source tarball links, but had no way to see what changed in a given version — users had to already know to go look at GitHub Releases separately.

This adds a **Release Notes** column to the SeaTunnel version table. For `v2.3.13` it links directly to https://github.com/apache/seatunnel/releases/tag/2.3.13 (the existing, authoritative release notes already maintained on GitHub for every tag). Older rows render `-` in that column for now, since only the current release is being backfilled here; the `SeaTunnel Web` table below is untouched (separate, experimental sub-project with its own release cadence).

Going forward, each `[Release][X.Y.Z] update docs for seatunnel website` PR can add one `releaseNotes` field to the new version's entry in `src/pages/download/st_data.json`, alongside the existing `sourceCode`/`binaryDistribution` fields.

## Files changed
- `src/pages/download/st_data.json` — add `releaseNotes` URL for the `v2.3.13` entry only
- `src/pages/download/index.jsx` — render a "Release Notes" column in the SeaTunnel table, linking out when the field is present

## Verification
- Diff reviewed: additive only, 5 lines inserted, 0 deletions, 2 files touched — no existing behavior, route, or data removed.
- **UI was not visually verified in a running dev server** — the local Docusaurus preview was stopped mid-startup at the requester's explicit instruction ("Stop the UI verification") before the page could be loaded in a browser. The change itself is a minimal, pattern-matched addition (same conditional-render/table-cell style already used elsewhere in this exact file for the bin/asc/sha512 links), but the rendered output has not been visually confirmed. Flagging this so a reviewer double-checks the `/download` page renders correctly before merge.