### PR TITLE
[Improve][Team] Visualize contributor network

### DIFF
--- a/src/pages/team/index.js
+++ b/src/pages/team/index.js
@@ -10,8 +10,42 @@ const avatarByUserId = new Map(
     avatarSrc.map((item) => [item.id, "data:image/png;base64," + item.avatar_base64])
 );
 
+/**
+ * Returns the embedded avatar for listed team members and a bounded GitHub thumbnail for
+ * generated contributors. The size constraint prevents the network view from downloading
+ * hundreds of original-resolution images when it enters the viewport.
+ */
 function getAvatarUrl(member) {
-    return avatarByUserId.get(member.userId) || member.avatarUrl || "";
+    const avatarUrl = avatarByUserId.get(member.userId) || member.avatarUrl || "";
+
+    if (!avatarUrl.startsWith("https://avatars.githubusercontent.com/")) {
+        return avatarUrl;
+    }
+    return avatarUrl + (avatarUrl.includes("?") ? "&" : "?") + "s=64";
+}
+
+const NETWORK_COLUMNS_PER_SIDE = 12;
+
+/**
+ * Produces a stable, evenly distributed position for each contributor around the project mark.
+ * Keeping this calculation deterministic prevents profiles from shifting between renders and
+ * preserves a clear central area for the SeaTunnel identity.
+ */
+function getContributorNetworkPosition(index, total) {
+    const contributorsPerSide = Math.ceil(total / 2);
+    const isLeftSide = index < contributorsPerSide;
+    const sideIndex = isLeftSide ? index : index - contributorsPerSide;
+    const rowCount = Math.ceil(contributorsPerSide / NETWORK_COLUMNS_PER_SIDE);
+    const column = sideIndex % NETWORK_COLUMNS_PER_SIDE;
+    const row = Math.floor(sideIndex / NETWORK_COLUMNS_PER_SIDE);
+    const columnProgress = column / (NETWORK_COLUMNS_PER_SIDE - 1);
+    const rowProgress = rowCount === 1 ? 0.5 : row / (rowCount - 1);
+    const x = isLeftSide ? 2 + columnProgress * 40 : 58 + columnProgress * 40;
+    const y = 8 + rowProgress * 84;
+    const drift = Math.sin((row + 1) * (column + 2)) * 0.7;
+    const size = index % 23 === 0 ? "large" : index % 7 === 0 ? "medium" : "small";
+
+    return {x: x + drift, y: y - drift, size};
 }
 
 function TeamSection({title, description, members}) {
@@ -37,6 +71,52 @@ function TeamSection({title, description, members}) {
     );
 }
 
+/**
+ * Renders the generated GitHub contributor list as an explorable relationship map.
+ * Every contributor remains an individual, keyboard-accessible link to their GitHub profile.
+ */
+function ContributorNetwork({contributors, countLabel}) {
+    const positionedContributors = contributors.map((member, index) => ({
+        member,
+        position: getContributorNetworkPosition(index, contributors.length),
+    }));
+
+    return (
+        <section className="contributor_network" aria-labelledby="contributors-title">
+            <svg className="contributor_network_lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                {positionedContributors.map(({member, position}) => (
+                    <line
+                        className="contributor_network_line"
+                        key={member.key || member.githubId}
+                        x1="50"
+                        y1="50"
+                        x2={position.x}
+                        y2={position.y}
+                    />
+                ))}
+            </svg>
+            <div className="contributor_network_count">{countLabel.replace('{count}', String(contributors.length))}</div>
+            <div className="contributor_network_identity">
+                <img src="/image/logo.png" alt="Apache SeaTunnel" />
+            </div>
+            <ul className="contributor_network_list">
+                {positionedContributors.map(({member, position}) => (
+                    <li
+                        className={'contributor_network_member contributor_network_member--' + position.size}
+                        key={member.key || member.githubId}
+                        style={{left: position.x + '%', top: position.y + '%'}}
+                    >
+                        <a href={member.profileUrl || "https://github.com/" + member.githubId} target="_blank" rel="noreferrer">
+                            <img src={getAvatarUrl(member)} alt={member.name || member.githubId} loading="lazy" />
+                            <span className="contributor_network_tooltip" aria-hidden="true">{member.githubId}</span>
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}
+
 export default function () {
     const isBrowser = useIsBrowser();
     const language = isBrowser && location.pathname.indexOf('/zh-CN/') === 0 ? 'zh-CN' : 'en';
@@ -54,14 +134,21 @@ export default function () {
 
     return (
         <Layout>
-            <div className="block team_page">
-                <h3 className="team_title">SeaTunnel Team</h3>
-                <p className="team_desc" dangerouslySetInnerHTML={ { __html: dataSource.info.desc } }/>
+            <div className="team_page">
+                <div className="block">
+                    <h3 className="team_title">SeaTunnel Team</h3>
+                    <p className="team_desc" dangerouslySetInnerHTML={ { __html: dataSource.info.desc } }/>
 
-                <TeamSection title="PMC" description={dataSource.info.tip} members={config.pmc}/>
+                    <TeamSection title="PMC" description={dataSource.info.tip} members={config.pmc}/>
 
-                <TeamSection title="Committer" description={dataSource.info.tip} members={config.committer}/>
-                <TeamSection title={dataSource.info.prContributorTitle} description={contributorDesc} members={contributors}/>
+                    <TeamSection title="Committer" description={dataSource.info.tip} members={config.committer}/>
+                    <h3 className="team_title" id="contributors-title">{dataSource.info.prContributorTitle}</h3>
+                    <p className="team_desc">{contributorDesc}</p>
+                </div>
+                <ContributorNetwork
+                    contributors={contributors}
+                    countLabel={dataSource.info.prContributorNetworkCount}
+                />
             </div>
         </Layout>
     );

--- a/src/pages/team/index.js
+++ b/src/pages/team/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import config from "./languages.json";
 import avatarSrc from "./github-avatars.json";
@@ -24,28 +24,98 @@ function getAvatarUrl(member) {
     return avatarUrl + (avatarUrl.includes("?") ? "&" : "?") + "s=64";
 }
 
-const NETWORK_COLUMNS_PER_SIDE = 12;
+const ORBIT_GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+const AVATAR_LOAD_CONCURRENCY = 8;
+const PARTICLE_COUNT = 120;
 
 /**
- * Produces a stable, evenly distributed position for each contributor around the project mark.
- * Keeping this calculation deterministic prevents profiles from shifting between renders and
- * preserves a clear central area for the SeaTunnel identity.
+ * Creates stable three-dimensional positions for every contributor in the orbit.
+ * The golden-angle distribution avoids visible rows while retaining a reproducible layout.
  */
-function getContributorNetworkPosition(index, total) {
-    const contributorsPerSide = Math.ceil(total / 2);
-    const isLeftSide = index < contributorsPerSide;
-    const sideIndex = isLeftSide ? index : index - contributorsPerSide;
-    const rowCount = Math.ceil(contributorsPerSide / NETWORK_COLUMNS_PER_SIDE);
-    const column = sideIndex % NETWORK_COLUMNS_PER_SIDE;
-    const row = Math.floor(sideIndex / NETWORK_COLUMNS_PER_SIDE);
-    const columnProgress = column / (NETWORK_COLUMNS_PER_SIDE - 1);
-    const rowProgress = rowCount === 1 ? 0.5 : row / (rowCount - 1);
-    const x = isLeftSide ? 2 + columnProgress * 40 : 58 + columnProgress * 40;
-    const y = 8 + rowProgress * 84;
-    const drift = Math.sin((row + 1) * (column + 2)) * 0.7;
-    const size = index % 23 === 0 ? "large" : index % 7 === 0 ? "medium" : "small";
+function createOrbitNodes(contributors) {
+    const total = contributors.length;
 
-    return {x: x + drift, y: y - drift, size};
+    return contributors.map((member, index) => {
+        const vertical = 1 - (index / Math.max(1, total - 1)) * 2;
+        const radial = Math.sqrt(Math.max(0, 1 - vertical * vertical));
+        const angle = index * ORBIT_GOLDEN_ANGLE;
+        const fill = 0.55 + ((index * 37) % 100) / 220;
+
+        return {
+            member,
+            x: Math.cos(angle) * radial * fill,
+            y: vertical * fill * 0.88,
+            z: Math.sin(angle) * radial * fill * 0.55,
+            size: index % 23 === 0 ? 20 : index % 7 === 0 ? 15 : 11,
+            progress: 0,
+        };
+    });
+}
+
+/**
+ * Rotates an orbit point and projects it into the two-dimensional canvas viewport.
+ * The returned depth controls drawing order, scale, and opacity for the 3D effect.
+ */
+function projectOrbitPoint(node, rotationY, rotationX, width, height, zoom) {
+    const entrance = 1 - Math.pow(1 - node.progress, 3);
+    const cosY = Math.cos(rotationY);
+    const sinY = Math.sin(rotationY);
+    const cosX = Math.cos(rotationX);
+    const sinX = Math.sin(rotationX);
+    const x = (node.x * cosY + node.z * sinY) * entrance;
+    const z = (-node.x * sinY + node.z * cosY) * entrance;
+    const y = (node.y * cosX - z * sinX) * entrance;
+    const depth = node.y * sinX + z * cosX;
+    const depthRatio = Math.max(0, Math.min(1, (depth + 0.8) / 1.6));
+    const scale = 0.42 + depthRatio * 0.58;
+
+    return {
+        node,
+        x: width / 2 + x * width * 0.52 * zoom,
+        y: height / 2 + y * height * 0.43 * zoom,
+        depth,
+        radius: node.size * scale,
+        opacity: 0.35 + depthRatio * 0.65,
+    };
+}
+
+/**
+ * Returns the smallest rotational delta so focus transitions never spin the orbit the long way.
+ */
+function shortestAngle(from, to) {
+    return ((to - from + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
+}
+
+/**
+ * Draws an avatar or an initials fallback without creating an additional DOM image per frame.
+ */
+function drawOrbitAvatar(context, projected, image, highlighted) {
+    const {member} = projected.node;
+    const radius = projected.radius * (highlighted ? 1.55 : 1);
+    const outerRadius = radius + 2;
+
+    context.save();
+    context.beginPath();
+    context.arc(projected.x, projected.y, radius, 0, Math.PI * 2);
+    context.clip();
+    if (image) {
+        context.drawImage(image, projected.x - radius, projected.y - radius, radius * 2, radius * 2);
+    } else {
+        context.fillStyle = projected.node.size > 15 ? '#2e6aed' : '#35aaa9';
+        context.fillRect(projected.x - radius, projected.y - radius, radius * 2, radius * 2);
+        context.fillStyle = '#ffffff';
+        context.font = '600 ' + Math.max(9, radius * 0.82) + 'px sans-serif';
+        context.textAlign = 'center';
+        context.textBaseline = 'middle';
+        context.fillText((member.name || member.githubId).slice(0, 1).toUpperCase(), projected.x, projected.y + 1);
+    }
+    context.restore();
+
+    context.beginPath();
+    context.arc(projected.x, projected.y, outerRadius, 0, Math.PI * 2);
+    context.lineWidth = highlighted ? 3 : 2;
+    context.strokeStyle = projected.node.size > 15 ? '#2e6aed' : 'rgba(46, 184, 167, 0.86)';
+    context.stroke();
 }
 
 function TeamSection({title, description, members}) {
@@ -72,47 +142,423 @@ function TeamSection({title, description, members}) {
 }
 
 /**
- * Renders the generated GitHub contributor list as an explorable relationship map.
- * Every contributor remains an individual, keyboard-accessible link to their GitHub profile.
+ * Renders the generated GitHub contributor list as a draggable three-dimensional orbit.
+ * Canvas provides smooth depth animation and an equivalent keyboard interaction model.
  */
-function ContributorNetwork({contributors, countLabel}) {
-    const positionedContributors = contributors.map((member, index) => ({
-        member,
-        position: getContributorNetworkPosition(index, contributors.length),
-    }));
+function ContributorNetwork({contributors, countLabel, hint, profileLabel, controlsLabel}) {
+    const canvasRef = useRef(null);
+    const [activeMember, setActiveMember] = useState(null);
+    const [profilePinned, setProfilePinned] = useState(false);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            return undefined;
+        }
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return undefined;
+        }
+        const nodes = createOrbitNodes(contributors);
+        const images = new Map();
+        const particles = Array.from({length: PARTICLE_COUNT}, (_, index) => ({
+            x: ((index * 73) % 101) / 100,
+            y: ((index * 31) % 101) / 100,
+            depth: ((index * 47) % 101) / 100,
+            size: 0.6 + ((index * 19) % 10) / 10,
+        }));
+        let disposed = false;
+        let animationFrame = 0;
+        let width = 0;
+        let height = 0;
+        let pixelRatio = 1;
+        let rotationY = 0.4;
+        let rotationX = 0.18;
+        let targetRotationY = rotationY;
+        let targetRotationX = rotationX;
+        let velocityY = 0;
+        let velocityX = 0;
+        let zoom = 1;
+        let targetZoom = 1;
+        let dragging = false;
+        let moved = false;
+        let pointerX = 0;
+        let pointerY = 0;
+        let lastTime = performance.now();
+        let activeNode = null;
+        let pinnedNode = null;
+        let projectedNodes = [];
+        let isVisible = false;
+        let assetsRequested = false;
+        let nextAvatarIndex = 0;
+        let activeAvatarLoads = 0;
+        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        function resizeCanvas() {
+            const rect = canvas.getBoundingClientRect();
+            pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+            width = Math.max(1, rect.width);
+            height = Math.max(1, rect.height);
+            canvas.width = Math.round(width * pixelRatio);
+            canvas.height = Math.round(height * pixelRatio);
+        }
+
+        function updateActiveNode(nextNode) {
+            if (activeNode === nextNode) {
+                return;
+            }
+            activeNode = nextNode;
+            setActiveMember(nextNode ? nextNode.member : null);
+        }
+
+        function loadAvatars() {
+            while (isVisible && !disposed && activeAvatarLoads < AVATAR_LOAD_CONCURRENCY && nextAvatarIndex < contributors.length) {
+                const member = contributors[nextAvatarIndex++];
+                const image = new Image();
+                const imageKey = member.key || member.githubId;
+                activeAvatarLoads += 1;
+                image.crossOrigin = 'anonymous';
+                image.onload = function () {
+                    if (!disposed) {
+                        images.set(imageKey, image);
+                        requestDraw();
+                    }
+                    activeAvatarLoads -= 1;
+                    loadAvatars();
+                };
+                image.onerror = function () {
+                    activeAvatarLoads -= 1;
+                    loadAvatars();
+                };
+                image.src = getAvatarUrl(member);
+            }
+        }
+
+        const centerLogo = new Image();
+        centerLogo.onload = function () {
+            if (!disposed) {
+                requestDraw();
+            }
+        };
+
+        /**
+         * Defers network and animation work until the contributor network is actually visible.
+         * This keeps the entrance animation observable and avoids consuming resources above the fold.
+         */
+        function activateOrbit() {
+            isVisible = true;
+            lastTime = performance.now();
+            if (!assetsRequested) {
+                assetsRequested = true;
+                centerLogo.src = '/image/logo.png';
+            }
+            loadAvatars();
+            requestDraw();
+        }
+
+        function drawCenterMark() {
+            const radius = 60;
+
+            context.save();
+            context.beginPath();
+            context.arc(width / 2, height / 2, radius, 0, Math.PI * 2);
+            context.fillStyle = '#ffffff';
+            context.fill();
+            context.lineWidth = 3;
+            context.strokeStyle = '#2e6aed';
+            context.stroke();
+            if (centerLogo.complete && centerLogo.naturalWidth) {
+                context.drawImage(centerLogo, width / 2 - 38, height / 2 - 42, 76, 82);
+            }
+            context.restore();
+        }
+
+        function drawScene() {
+            context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+            context.clearRect(0, 0, width, height);
+
+            particles.forEach((particle) => {
+                const x = particle.x * width + Math.sin(rotationY + particle.y * Math.PI) * 16;
+                const y = particle.y * height + Math.cos(rotationY + particle.x * Math.PI) * 8;
+                context.beginPath();
+                context.arc(x, y, particle.size + particle.depth, 0, Math.PI * 2);
+                context.fillStyle = 'rgba(65, 156, 230, ' + (0.08 + particle.depth * 0.18) + ')';
+                context.fill();
+            });
+
+            projectedNodes = nodes.map((node) => projectOrbitPoint(node, rotationY, rotationX, width, height, zoom));
+            context.lineWidth = 1;
+            projectedNodes.forEach((projected) => {
+                context.beginPath();
+                context.moveTo(width / 2, height / 2);
+                context.lineTo(projected.x, projected.y);
+                context.strokeStyle = 'rgba(69, 125, 241, ' + (0.04 + projected.opacity * 0.1) + ')';
+                context.stroke();
+            });
+
+            projectedNodes.sort((left, right) => left.depth - right.depth).forEach((projected) => {
+                const imageKey = projected.node.member.key || projected.node.member.githubId;
+                const highlighted = projected.node === activeNode || projected.node === pinnedNode;
+                context.globalAlpha = projected.opacity;
+                drawOrbitAvatar(context, projected, images.get(imageKey), highlighted);
+            });
+            context.globalAlpha = 1;
+            drawCenterMark();
+        }
+
+        function isStillAnimating() {
+            return isVisible && (!reduceMotion || dragging || Math.abs(velocityY) > 0.0001 || Math.abs(velocityX) > 0.0001 || pinnedNode || nodes.some((node) => node.progress < 1));
+        }
+
+        function animate(timestamp) {
+            const delta = Math.min(2, (timestamp - lastTime) / 16.67);
+            lastTime = timestamp;
+            animationFrame = 0;
+            nodes.forEach((node) => {
+                node.progress = Math.min(1, node.progress + 0.035 * delta);
+            });
+            if (pinnedNode) {
+                rotationY += shortestAngle(rotationY, targetRotationY) * 0.055;
+                rotationX += (targetRotationX - rotationX) * 0.055;
+            } else if (!dragging) {
+                rotationY += velocityY + (reduceMotion ? 0 : 0.0007 * delta);
+                rotationX += velocityX;
+                velocityY *= 0.965;
+                velocityX *= 0.94;
+                rotationX += (0.15 - rotationX) * 0.006;
+                rotationX = Math.max(-1.1, Math.min(1.1, rotationX));
+            }
+            zoom += (targetZoom - zoom) * 0.05;
+            drawScene();
+            if (!disposed && isStillAnimating()) {
+                animationFrame = requestAnimationFrame(animate);
+            }
+        }
+
+        function requestDraw() {
+            if (isVisible && !animationFrame) {
+                animationFrame = requestAnimationFrame(animate);
+            }
+        }
+
+        function getPointerPosition(event) {
+            const rect = canvas.getBoundingClientRect();
+            return {x: event.clientX - rect.left, y: event.clientY - rect.top};
+        }
+
+        function pickNode(position) {
+            let closest = null;
+            let shortestDistance = Infinity;
+            projectedNodes.forEach((projected) => {
+                const distance = Math.hypot(projected.x - position.x, projected.y - position.y);
+                if (distance <= projected.radius + 8 && distance < shortestDistance) {
+                    closest = projected.node;
+                    shortestDistance = distance;
+                }
+            });
+            return closest;
+        }
+
+        function focusNode(node) {
+            const targetY = Math.atan2(-node.x, node.z);
+            const rotatedZ = -node.x * Math.sin(targetY) + node.z * Math.cos(targetY);
+            targetRotationY = rotationY + shortestAngle(rotationY, targetY);
+            targetRotationX = Math.max(-0.8, Math.min(0.8, Math.atan2(node.y, rotatedZ)));
+            pinnedNode = node;
+            targetZoom = 1.22;
+        }
+
+        function releaseFocus() {
+            pinnedNode = null;
+            targetZoom = 1;
+            setProfilePinned(false);
+            updateActiveNode(null);
+        }
+
+        function onPointerDown(event) {
+            const position = getPointerPosition(event);
+            dragging = true;
+            moved = false;
+            pointerX = position.x;
+            pointerY = position.y;
+            velocityY = 0;
+            velocityX = 0;
+            canvas.setPointerCapture(event.pointerId);
+            canvas.style.cursor = 'grabbing';
+            requestDraw();
+        }
+
+        function onPointerMove(event) {
+            const position = getPointerPosition(event);
+            if (dragging) {
+                const deltaX = position.x - pointerX;
+                const deltaY = position.y - pointerY;
+                if (Math.abs(deltaX) + Math.abs(deltaY) > 2) {
+                    moved = true;
+                    releaseFocus();
+                }
+                velocityY = deltaX * 0.006;
+                velocityX = deltaY * 0.006;
+                rotationY += velocityY;
+                rotationX = Math.max(-1.1, Math.min(1.1, rotationX + velocityX));
+                pointerX = position.x;
+                pointerY = position.y;
+                requestDraw();
+                return;
+            }
+            const nextNode = pickNode(position);
+            if (!pinnedNode) {
+                updateActiveNode(nextNode);
+            }
+            canvas.style.cursor = nextNode ? 'pointer' : 'grab';
+        }
+
+        function onPointerUp(event) {
+            dragging = false;
+            if (canvas.hasPointerCapture(event.pointerId)) {
+                canvas.releasePointerCapture(event.pointerId);
+            }
+            canvas.style.cursor = 'grab';
+            requestDraw();
+        }
+
+        function onClick(event) {
+            if (moved) {
+                return;
+            }
+            const node = pickNode(getPointerPosition(event));
+            if (node) {
+                updateActiveNode(node);
+                setProfilePinned(true);
+                focusNode(node);
+            } else {
+                releaseFocus();
+            }
+            requestDraw();
+        }
+
+        function onPointerLeave() {
+            if (!pinnedNode && !dragging) {
+                updateActiveNode(null);
+            }
+        }
+
+        /**
+         * Selects an adjacent contributor without introducing hundreds of invisible tab stops.
+         */
+        function selectAdjacentNode(direction) {
+            const activeIndex = activeNode ? nodes.indexOf(activeNode) : direction > 0 ? -1 : 0;
+            const nextIndex = (activeIndex + direction + nodes.length) % nodes.length;
+            const nextNode = nodes[nextIndex];
+
+            pinnedNode = null;
+            targetZoom = 1;
+            updateActiveNode(nextNode);
+            setProfilePinned(false);
+            requestDraw();
+        }
+
+        function onKeyDown(event) {
+            if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                event.preventDefault();
+                selectAdjacentNode(1);
+                return;
+            }
+            if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                event.preventDefault();
+                selectAdjacentNode(-1);
+                return;
+            }
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                const node = activeNode || nodes[0];
+                updateActiveNode(node);
+                setProfilePinned(true);
+                focusNode(node);
+                requestDraw();
+                return;
+            }
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                releaseFocus();
+                requestDraw();
+            }
+        }
+
+        const resizeObserver = new ResizeObserver(function () {
+            resizeCanvas();
+            requestDraw();
+        });
+        const intersectionObserver = 'IntersectionObserver' in window
+            ? new IntersectionObserver(function (entries) {
+                isVisible = entries.some((entry) => entry.isIntersecting);
+                if (isVisible) {
+                    activateOrbit();
+                } else if (animationFrame) {
+                    cancelAnimationFrame(animationFrame);
+                    animationFrame = 0;
+                }
+            }, {threshold: 0.01})
+            : null;
+        resizeObserver.observe(canvas);
+        if (intersectionObserver) {
+            intersectionObserver.observe(canvas);
+        }
+        canvas.addEventListener('pointerdown', onPointerDown);
+        canvas.addEventListener('pointermove', onPointerMove);
+        canvas.addEventListener('pointerup', onPointerUp);
+        canvas.addEventListener('pointercancel', onPointerUp);
+        canvas.addEventListener('pointerleave', onPointerLeave);
+        canvas.addEventListener('click', onClick);
+        canvas.addEventListener('keydown', onKeyDown);
+        resizeCanvas();
+        if (!intersectionObserver) {
+            activateOrbit();
+        }
+
+        return function () {
+            disposed = true;
+            if (animationFrame) {
+                cancelAnimationFrame(animationFrame);
+            }
+            resizeObserver.disconnect();
+            if (intersectionObserver) {
+                intersectionObserver.disconnect();
+            }
+            canvas.removeEventListener('pointerdown', onPointerDown);
+            canvas.removeEventListener('pointermove', onPointerMove);
+            canvas.removeEventListener('pointerup', onPointerUp);
+            canvas.removeEventListener('pointercancel', onPointerUp);
+            canvas.removeEventListener('pointerleave', onPointerLeave);
+            canvas.removeEventListener('click', onClick);
+            canvas.removeEventListener('keydown', onKeyDown);
+        };
+    }, [contributors]);
 
     return (
         <section className="contributor_network" aria-labelledby="contributors-title">
-            <svg className="contributor_network_lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-                {positionedContributors.map(({member, position}) => (
-                    <line
-                        className="contributor_network_line"
-                        key={member.key || member.githubId}
-                        x1="50"
-                        y1="50"
-                        x2={position.x}
-                        y2={position.y}
-                    />
-                ))}
-            </svg>
+            <canvas
+                className="contributor_network_canvas"
+                ref={canvasRef}
+                role="application"
+                tabIndex="0"
+                aria-label={controlsLabel}
+                aria-describedby="contributor-network-hint"
+            />
             <div className="contributor_network_count">{countLabel.replace('{count}', String(contributors.length))}</div>
-            <div className="contributor_network_identity">
-                <img src="/image/logo.png" alt="Apache SeaTunnel" />
+            <div className={'contributor_network_readout' + (activeMember ? ' show' : '')} aria-live="polite">
+                {activeMember && (
+                    <>
+                        <strong>{activeMember.name || activeMember.githubId}</strong>
+                        <span>{activeMember.githubId}</span>
+                        {profilePinned && (
+                            <a href={activeMember.profileUrl || "https://github.com/" + activeMember.githubId} target="_blank" rel="noreferrer">{profileLabel}</a>
+                        )}
+                    </>
+                )}
             </div>
-            <ul className="contributor_network_list">
-                {positionedContributors.map(({member, position}) => (
-                    <li
-                        className={'contributor_network_member contributor_network_member--' + position.size}
-                        key={member.key || member.githubId}
-                        style={{left: position.x + '%', top: position.y + '%'}}
-                    >
-                        <a href={member.profileUrl || "https://github.com/" + member.githubId} target="_blank" rel="noreferrer">
-                            <img src={getAvatarUrl(member)} alt={member.name || member.githubId} loading="lazy" />
-                            <span className="contributor_network_tooltip" aria-hidden="true">{member.githubId}</span>
-                        </a>
-                    </li>
-                ))}
-            </ul>
+            <p className="contributor_network_hint" id="contributor-network-hint">{hint}</p>
         </section>
     );
 }
@@ -148,6 +594,9 @@ export default function () {
                 <ContributorNetwork
                     contributors={contributors}
                     countLabel={dataSource.info.prContributorNetworkCount}
+                    hint={dataSource.info.prContributorNetworkHint}
+                    profileLabel={dataSource.info.prContributorNetworkProfile}
+                    controlsLabel={dataSource.info.prContributorNetworkControls}
                 />
             </div>
         </Layout>

--- a/src/pages/team/index.less
+++ b/src/pages/team/index.less
@@ -86,4 +86,183 @@
       }
     }
   }
+
+  .contributor_network {
+    position: relative;
+    width: 100%;
+    height: 700px;
+    min-width: 1200px;
+    margin: 0 0 72px;
+    overflow: hidden;
+    isolation: isolate;
+    border-top: 1px solid rgba(58, 123, 255, 0.12);
+    border-bottom: 1px solid rgba(58, 123, 255, 0.12);
+    background:
+      radial-gradient(circle at center, rgba(225, 239, 255, 0.92) 0, rgba(235, 247, 255, 0.6) 25%, rgba(255, 255, 255, 0) 68%),
+      linear-gradient(90deg, #ffffff 0%, #f6fbff 50%, #f1fbf8 100%);
+
+    &::before {
+      position: absolute;
+      z-index: -1;
+      top: 50%;
+      left: 50%;
+      width: 560px;
+      height: 560px;
+      border: 1px solid rgba(82, 143, 255, 0.08);
+      border-radius: 50%;
+      content: '';
+      transform: translate(-50%, -50%);
+    }
+
+    .contributor_network_lines {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+    }
+
+    .contributor_network_line {
+      stroke: rgba(69, 125, 241, 0.14);
+      stroke-width: 1;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .contributor_network_count {
+      position: absolute;
+      z-index: 3;
+      top: 22px;
+      right: 36px;
+      padding: 8px 16px;
+      border: 1px solid rgba(47, 100, 224, 0.13);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.78);
+      box-shadow: 0 10px 24px rgba(45, 94, 181, 0.08);
+      color: #2862d8;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .contributor_network_identity {
+      position: absolute;
+      z-index: 2;
+      top: 50%;
+      left: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 120px;
+      height: 120px;
+      overflow: hidden;
+      border: 3px solid #2e6aed;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 12px 32px rgba(28, 91, 224, 0.24);
+      transform: translate(-50%, -50%);
+
+      img {
+        width: 82px;
+        height: 88px;
+        object-fit: contain;
+      }
+    }
+
+    .contributor_network_list {
+      width: 100%;
+      height: 100%;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    .contributor_network_member {
+      position: absolute;
+      z-index: 1;
+      display: block;
+      width: 21px;
+      height: 21px;
+      margin: 0;
+      transform: translate(-50%, -50%);
+
+      a,
+      img {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+
+      a {
+        border: 2px solid rgba(71, 139, 255, 0.78);
+        border-radius: 50%;
+        background: #ffffff;
+        box-shadow: 0 4px 11px rgba(28, 91, 189, 0.18);
+        transition: transform 160ms ease, box-shadow 160ms ease;
+      }
+
+      img {
+        border-radius: 50%;
+        object-fit: cover;
+      }
+
+      &.contributor_network_member--medium {
+        width: 27px;
+        height: 27px;
+
+        a {
+          border-color: rgba(46, 184, 167, 0.8);
+        }
+      }
+
+      &.contributor_network_member--large {
+        width: 34px;
+        height: 34px;
+
+        a {
+          border-width: 3px;
+          border-color: #2e6aed;
+        }
+      }
+
+      &:hover,
+      &:focus-within {
+        z-index: 4;
+
+        a {
+          box-shadow: 0 8px 20px rgba(28, 91, 189, 0.28);
+          transform: scale(1.35);
+        }
+
+        .contributor_network_tooltip {
+          opacity: 1;
+          transform: translate(-50%, 0);
+        }
+      }
+
+      a:focus-visible {
+        outline: 3px solid #f7bd46;
+        outline-offset: 3px;
+      }
+    }
+
+    .contributor_network_tooltip {
+      position: absolute;
+      top: calc(100% + 8px);
+      left: 50%;
+      z-index: 5;
+      padding: 3px 8px;
+      border-radius: 5px;
+      background: #18274d;
+      box-shadow: 0 4px 12px rgba(15, 37, 83, 0.2);
+      color: #ffffff;
+      font-size: 11px;
+      line-height: 18px;
+      opacity: 0;
+      pointer-events: none;
+      transform: translate(-50%, 4px);
+      transition: opacity 160ms ease, transform 160ms ease;
+      white-space: nowrap;
+    }
+  }
 }

--- a/src/pages/team/index.less
+++ b/src/pages/team/index.less
@@ -114,18 +114,19 @@
       transform: translate(-50%, -50%);
     }
 
-    .contributor_network_lines {
+    .contributor_network_canvas {
       position: absolute;
       inset: 0;
+      display: block;
       width: 100%;
       height: 100%;
-      pointer-events: none;
-    }
+      cursor: grab;
+      touch-action: none;
 
-    .contributor_network_line {
-      stroke: rgba(69, 125, 241, 0.14);
-      stroke-width: 1;
-      vector-effect: non-scaling-stroke;
+      &:focus-visible {
+        outline: 3px solid #f7bd46;
+        outline-offset: -5px;
+      }
     }
 
     .contributor_network_count {
@@ -145,124 +146,67 @@
       text-transform: uppercase;
     }
 
-    .contributor_network_identity {
+    .contributor_network_readout {
       position: absolute;
       z-index: 2;
-      top: 50%;
-      left: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 120px;
-      height: 120px;
-      overflow: hidden;
-      border: 3px solid #2e6aed;
-      border-radius: 50%;
-      background: #ffffff;
-      box-shadow: 0 12px 32px rgba(28, 91, 224, 0.24);
-      transform: translate(-50%, -50%);
+      top: 82px;
+      right: 36px;
+      max-width: 280px;
+      padding: 13px 17px;
+      border: 1px solid rgba(47, 100, 224, 0.15);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.85);
+      box-shadow: 0 14px 34px rgba(26, 39, 77, 0.12);
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(-6px);
+      transition: opacity 180ms ease, transform 180ms ease;
 
-      img {
-        width: 82px;
-        height: 88px;
-        object-fit: contain;
+      &.show {
+        opacity: 1;
+        pointer-events: auto;
+        transform: none;
       }
-    }
 
-    .contributor_network_list {
-      width: 100%;
-      height: 100%;
-      padding: 0;
-      margin: 0;
-      list-style: none;
-    }
-
-    .contributor_network_member {
-      position: absolute;
-      z-index: 1;
-      display: block;
-      width: 21px;
-      height: 21px;
-      margin: 0;
-      transform: translate(-50%, -50%);
-
-      a,
-      img {
+      strong,
+      span,
+      a {
         display: block;
-        width: 100%;
-        height: 100%;
+      }
+
+      strong {
+        color: #18274d;
+        font-size: 15px;
+      }
+
+      span {
+        color: #4a6080;
+        font-size: 12px;
       }
 
       a {
-        border: 2px solid rgba(71, 139, 255, 0.78);
-        border-radius: 50%;
-        background: #ffffff;
-        box-shadow: 0 4px 11px rgba(28, 91, 189, 0.18);
-        transition: transform 160ms ease, box-shadow 160ms ease;
-      }
-
-      img {
-        border-radius: 50%;
-        object-fit: cover;
-      }
-
-      &.contributor_network_member--medium {
-        width: 27px;
-        height: 27px;
-
-        a {
-          border-color: rgba(46, 184, 167, 0.8);
-        }
-      }
-
-      &.contributor_network_member--large {
-        width: 34px;
-        height: 34px;
-
-        a {
-          border-width: 3px;
-          border-color: #2e6aed;
-        }
-      }
-
-      &:hover,
-      &:focus-within {
-        z-index: 4;
-
-        a {
-          box-shadow: 0 8px 20px rgba(28, 91, 189, 0.28);
-          transform: scale(1.35);
-        }
-
-        .contributor_network_tooltip {
-          opacity: 1;
-          transform: translate(-50%, 0);
-        }
-      }
-
-      a:focus-visible {
-        outline: 3px solid #f7bd46;
-        outline-offset: 3px;
+        margin-top: 4px;
+        color: #2862d8;
+        font-size: 12px;
+        font-weight: 600;
       }
     }
 
-    .contributor_network_tooltip {
+    .contributor_network_hint {
       position: absolute;
-      top: calc(100% + 8px);
+      z-index: 2;
+      bottom: 22px;
       left: 50%;
-      z-index: 5;
-      padding: 3px 8px;
-      border-radius: 5px;
-      background: #18274d;
-      box-shadow: 0 4px 12px rgba(15, 37, 83, 0.2);
-      color: #ffffff;
-      font-size: 11px;
-      line-height: 18px;
-      opacity: 0;
+      margin: 0;
+      color: #4a6080;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
       pointer-events: none;
-      transform: translate(-50%, 4px);
-      transition: opacity 160ms ease, transform 160ms ease;
+      text-transform: uppercase;
+      transform: translateX(-50%);
       white-space: nowrap;
     }
+
   }
 }

--- a/src/pages/team/languages.json
+++ b/src/pages/team/languages.json
@@ -4,7 +4,8 @@
       "desc": "SeaTunnel 社区由贡献者组成。 贡献者可以直接访问 SeaTunnel 项目的源代码并参与贡献当中(包括但不限于代码的贡献)。 贡献者通过提交补丁和建议来改善项目。 该项目的贡献者数量是无限的。 无论是琐碎的清理工作，重要的新功能还是其他重大的奖励，对 SeaTunnel 所做的所有贡献都将受到极大的赞赏。",
       "tip": "(排名不分先后)",
       "prContributorTitle": "Contributors",
-      "prContributorDesc": "GitHub 当前将 Apache SeaTunnel 统计为 {totalCount} 位 Contributors。考虑到其中已有 {existingCount} 位已在上方 PMC 与 Committer 中展示，下面仅补充展示其余 {count} 位具名贡献者。"
+      "prContributorDesc": "GitHub 当前将 Apache SeaTunnel 统计为 {totalCount} 位 Contributors。考虑到其中已有 {existingCount} 位已在上方 PMC 与 Committer 中展示，下面仅补充展示其余 {count} 位具名贡献者。",
+      "prContributorNetworkCount": "{count} 位贡献者"
     }
   },
   "en": {
@@ -12,7 +13,8 @@
       "desc": "The SeaTunnel team is comprised of Members and Contributors. Members have direct access to the source of SeaTunnel project and actively evolve the code-base. Contributors improve the project through submission of patches and suggestions to the Members. The number of Contributors to the project is unbounded. All contributions to SeaTunnel are greatly appreciated, whether for trivial cleanups, big new features or other material rewards.",
       "tip": "(In no particular order)",
       "prContributorTitle": "Contributors",
-      "prContributorDesc": "GitHub currently counts {totalCount} contributors for the Apache SeaTunnel repository. Since {existingCount} of them are already listed above as PMC members or committers, the remaining {count} identified contributors are shown below."
+      "prContributorDesc": "GitHub currently counts {totalCount} contributors for the Apache SeaTunnel repository. Since {existingCount} of them are already listed above as PMC members or committers, the remaining {count} identified contributors are shown below.",
+      "prContributorNetworkCount": "{count} contributors"
     }
   },
   "pmc": [

--- a/src/pages/team/languages.json
+++ b/src/pages/team/languages.json
@@ -5,7 +5,10 @@
       "tip": "(排名不分先后)",
       "prContributorTitle": "Contributors",
       "prContributorDesc": "GitHub 当前将 Apache SeaTunnel 统计为 {totalCount} 位 Contributors。考虑到其中已有 {existingCount} 位已在上方 PMC 与 Committer 中展示，下面仅补充展示其余 {count} 位具名贡献者。",
-      "prContributorNetworkCount": "{count} 位贡献者"
+      "prContributorNetworkCount": "{count} 位贡献者",
+      "prContributorNetworkHint": "拖动探索 · 点击贡献者聚焦 · 悬停查看详情",
+      "prContributorNetworkProfile": "查看 GitHub 主页",
+      "prContributorNetworkControls": "贡献者关系图。使用方向键选择贡献者，按 Enter 聚焦，按 Escape 清除选择，然后按 Tab 访问所选贡献者的 GitHub 主页。"
     }
   },
   "en": {
@@ -14,7 +17,10 @@
       "tip": "(In no particular order)",
       "prContributorTitle": "Contributors",
       "prContributorDesc": "GitHub currently counts {totalCount} contributors for the Apache SeaTunnel repository. Since {existingCount} of them are already listed above as PMC members or committers, the remaining {count} identified contributors are shown below.",
-      "prContributorNetworkCount": "{count} contributors"
+      "prContributorNetworkCount": "{count} contributors",
+      "prContributorNetworkHint": "Drag to explore · Click a contributor to focus · Hover for details",
+      "prContributorNetworkProfile": "View GitHub profile",
+      "prContributorNetworkControls": "Contributor network. Use the arrow keys to select a contributor, Enter to focus, Escape to clear the selection, then Tab to visit the selected GitHub profile."
     }
   },
   "pmc": [


### PR DESCRIPTION
## Summary
- Replace the static contributor map with a dynamic, depth-aware canvas orbit that scatters from the SeaTunnel mark, idles gently, and supports drag inertia.
- Match the reference click behavior: hovering shows contributor details; click or keyboard Enter/Space rotates the selected avatar to the front, zooms in, pins it, and reveals its GitHub profile link.
- Show the selected contributor card on the right below the count badge.
- Start drawing and the bounded eight-at-a-time avatar queue only once the section enters the viewport; pause rendering and queued loading while it is out of view.
- Keep the interaction keyboard-operable: arrow keys select, Enter/Space activates, Escape clears, and Tab reaches the activated profile link.

## Verification
- npm run sync
- Docusaurus local preview at http://127.0.0.1:3100/team compiled successfully.
- Browser checks covered off-screen idle state, viewport activation, off-screen pause, hover, click focus, drag, right-aligned card, keyboard selection/activation, visible keyboard focus, and the selected profile link.
- JSON localization check, JSX parse, LESS compilation, and git diff --check.

## Review
- Independent maintainer review passed after the final interaction and accessibility checks.

## Scope and compatibility
- Only src/pages/team/index.js, src/pages/team/index.less, and src/pages/team/languages.json change.
- No contributor data schema, public configuration, registration, packaging, or dependency changes.

## CI
- GitHub checks have not reported for the updated head yet.